### PR TITLE
[Feat] 유저 서비스, dto, 테스트 추가 

### DIFF
--- a/src/main/java/me/snaptime/user/data/domain/User.java
+++ b/src/main/java/me/snaptime/user/data/domain/User.java
@@ -22,8 +22,8 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_name",nullable = false)
     private String name;
 
-    @Column(name = "user_logninId",nullable = false, unique = true)
-    private String longinId;
+    @Column(name = "user_loginId",nullable = false, unique = true)
+    private String loginId;
 
     @Column(name = "user_password",nullable = false)
     private String password;
@@ -41,11 +41,17 @@ public class User extends BaseTimeEntity {
     protected User(Long Id, String name,String loginId,String password, String email, String birthDay){
         this.Id = Id;
         this.name = name;
-        this.longinId = loginId;
+        this.loginId = loginId;
         this.password =password;
         this.email = email;
         this.birthDay = birthDay;
     }
+
+    public void updateUserName(String name) { this.name = name;}
+    public void updateUserLoginId(String loginId) { this.loginId = loginId;}
+    public void updateUserEmail(String email) { this.email = email;}
+    public void updateUserBirthDay(String birthDay) { this.birthDay = birthDay;}
+
 
 
 }

--- a/src/main/java/me/snaptime/user/data/domain/User.java
+++ b/src/main/java/me/snaptime/user/data/domain/User.java
@@ -34,7 +34,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_birthDay",nullable = false)
     private String birthDay;
 
-    @OneToOne(mappedBy = "user",cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private ProfilePhoto profilePhoto;
 
     @Builder
@@ -51,7 +51,5 @@ public class User extends BaseTimeEntity {
     public void updateUserLoginId(String loginId) { this.loginId = loginId;}
     public void updateUserEmail(String email) { this.email = email;}
     public void updateUserBirthDay(String birthDay) { this.birthDay = birthDay;}
-
-
 
 }

--- a/src/main/java/me/snaptime/user/data/dto/request/UserRequestDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/request/UserRequestDto.java
@@ -1,0 +1,37 @@
+package me.snaptime.user.data.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserRequestDto(
+        @Schema(
+                example = "홍길순",
+                description = "유저의 이름을 입력해주세요"
+        )
+        @NotBlank(message = "유저 이름 입력은 필수입니다.")
+        String name,
+        @Schema(
+                example = "kang4746",
+                description = "유저의 로그인 아이디를 입력해주세요"
+        )
+        @NotBlank(message = "유저 로그인 아이디 입력은 필수입니다.")
+        String loginId,
+        @Schema(
+                example = "password",
+                description = "유저의 비밀번호를 입력해주세요"
+        )
+        @NotBlank(message = "유저 비밀번호 입력은 필수입니다.")
+        String password,
+        @Schema(
+                example = "strong@gmail.com",
+                description = "유저의 이메일을 입력해주세요"
+        )
+        @NotBlank(message = "유저 이메일 입력은 필수입니다.")
+        String email,
+        @Schema(
+                example = "1999-10-29",
+                description = "유저의 생년월일을 입력해주세요"
+        )
+        @NotBlank(message = "유저 생년월일 입력은 필수입니다.")
+        String birthDay
+){}

--- a/src/main/java/me/snaptime/user/data/dto/request/UserUpdateDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/request/UserUpdateDto.java
@@ -1,0 +1,32 @@
+package me.snaptime.user.data.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserUpdateDto(
+        @Schema(
+                example = "홍길순",
+                description = "유저의 이름을 입력해주세요"
+        )
+        @NotBlank(message = "유저 이름 입력은 필수입니다.")
+        String name,
+        @Schema(
+                example = "kang4746",
+                description = "유저의 로그인 아이디를 입력해주세요"
+        )
+        @NotBlank(message = "유저 로그인 아이디 입력은 필수입니다.")
+        String loginId,
+        @Schema(
+                example = "strong@gmail.com",
+                description = "유저의 이메일을 입력해주세요"
+        )
+        @NotBlank(message = "유저 이메일 입력은 필수입니다.")
+        String email,
+        @Schema(
+                example = "1999-10-29",
+                description = "유저의 생년월일을 입력해주세요"
+        )
+        @NotBlank(message = "유저 생년월일 입력은 필수입니다.")
+        String birthDay
+
+){}

--- a/src/main/java/me/snaptime/user/data/dto/response/UserResponseDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/response/UserResponseDto.java
@@ -1,0 +1,27 @@
+package me.snaptime.user.data.dto.response;
+
+
+import lombok.Builder;
+import me.snaptime.user.data.domain.User;
+
+@Builder
+public record UserResponseDto (
+    Long id,
+    String name,
+    String loginId,
+    String password,
+    String email,
+    String birthDay
+){
+    public static UserResponseDto toDto(User user){
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .loginId(user.getLoginId())
+                .password(user.getPassword())
+                .email(user.getEmail())
+                .birthDay(user.getBirthDay())
+                .build();
+    }
+
+}

--- a/src/main/java/me/snaptime/user/service/UserService.java
+++ b/src/main/java/me/snaptime/user/service/UserService.java
@@ -1,0 +1,72 @@
+package me.snaptime.user.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.snaptime.user.data.domain.User;
+import me.snaptime.user.data.dto.request.UserRequestDto;
+import me.snaptime.user.data.dto.request.UserUpdateDto;
+import me.snaptime.user.data.dto.response.UserResponseDto;
+import me.snaptime.user.data.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserResponseDto getUser(Long id){
+        User user = userRepository.findById(id).orElseThrow(()-> new NoSuchElementException("해당 로그인 아이드의 유저를 찾을 수 없습니다."));
+
+        return UserResponseDto.toDto(user);
+    }
+
+    public UserResponseDto signUp(UserRequestDto userRequestDto){
+
+        User user = User.builder()
+                .Id(null)
+                .name(userRequestDto.name())
+                .loginId(userRequestDto.loginId())
+                .password(userRequestDto.password())
+                .email(userRequestDto.email())
+                .birthDay(userRequestDto.birthDay())
+                .build();
+
+        return UserResponseDto.toDto(userRepository.save(user));
+    }
+
+    public void deleteUser(Long id){
+        User user = userRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당 id의 유저가 존재하지 않습니다."));
+        userRepository.deleteById(user.getId());
+    }
+
+    public UserResponseDto updateUser(Long id, UserUpdateDto userUpdateDto){
+
+        User user = userRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당 loginId의 유저가 존재하지 않습니다."));
+
+        if (userUpdateDto.name() !=null && !userUpdateDto.name().isEmpty() && !userUpdateDto.name().equals("string")){
+            user.updateUserName(userUpdateDto.name());
+        }
+
+        if (userUpdateDto.loginId() !=null && !userUpdateDto.loginId().isEmpty()&& !userUpdateDto.loginId().equals("string")){
+            user.updateUserLoginId(userUpdateDto.loginId());
+        }
+
+        if (userUpdateDto.email() !=null && !userUpdateDto.email().isEmpty()&& !userUpdateDto.email().equals("string")){
+            user.updateUserEmail(userUpdateDto.email());
+        }
+
+        if (userUpdateDto.birthDay() !=null && !userUpdateDto.birthDay().isEmpty()&& !userUpdateDto.birthDay().equals("string")){
+            user.updateUserBirthDay(userUpdateDto.birthDay());
+        }
+
+        return UserResponseDto.toDto(userRepository.save(user));
+    }
+
+}

--- a/src/test/java/me/snaptime/user/service/UserServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/UserServiceTest.java
@@ -1,0 +1,145 @@
+package me.snaptime.user.service;
+
+import me.snaptime.user.data.domain.User;
+import me.snaptime.user.data.dto.request.UserRequestDto;
+import me.snaptime.user.data.dto.request.UserUpdateDto;
+import me.snaptime.user.data.dto.response.UserResponseDto;
+import me.snaptime.user.data.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class UserServiceTest {
+
+
+//    @InjectMocks
+//    private UserService userService;
+//
+//    @Mock
+//    private UserRepository userRepository;
+
+    private final UserRepository userRepository = Mockito.mock(UserRepository.class);
+    private UserService userService;
+
+    @BeforeEach
+    public void setUpTestSet() {
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    @DisplayName("given_when_then 방식으로 getUser 서비스 성공 테스트")
+    void getUser() {
+        //given
+        User givenUser = User.builder()
+                .Id(1L)
+                .name("홍길순")
+                .loginId("kang4746")
+                .password("test1234")
+                .email("strong@gmail.com")
+                .birthDay("1999-10-29")
+                .build();
+
+        Mockito.when(userRepository.findById(1L))
+                .thenReturn(Optional.of(givenUser));
+        //when
+        UserResponseDto userResponseDto = userService.getUser(1L);
+
+        //then
+        Assertions.assertEquals(givenUser.getId(),userResponseDto.id());
+        Assertions.assertEquals(givenUser.getName(),userResponseDto.name());
+        Assertions.assertEquals(givenUser.getLoginId(),userResponseDto.loginId());
+        Assertions.assertEquals(givenUser.getPassword(),userResponseDto.password());
+        Assertions.assertEquals(givenUser.getEmail(),userResponseDto.email());
+        Assertions.assertEquals(givenUser.getBirthDay(),userResponseDto.birthDay());
+
+        verify(userRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("given_when_then 방식으로 signUp 서비스 성공 테스트")
+    void signUp() {
+        //given
+        UserRequestDto givenRequest = new UserRequestDto("홍길순","kang4746","test1234","strong@gmail.com","1999-10-29");
+
+
+        //userRepository.save(any(User.class)) 메서드가 호출되면
+        // 첫 번째 전달된 User 객체를 반환하도록(Mockito의 returnsFirstArg() 메서드를 사용하여) 설정하는 것입니다.
+        Mockito.when(userRepository.save(any(User.class)))
+                .then(returnsFirstArg());
+        //when
+        UserResponseDto userResponseDto = userService.signUp(givenRequest);
+
+        //then
+        Assertions.assertEquals(givenRequest.name(),userResponseDto.name());
+        Assertions.assertEquals(givenRequest.loginId(),userResponseDto.loginId());
+        Assertions.assertEquals(givenRequest.password(),userResponseDto.password());
+        Assertions.assertEquals(givenRequest.email(),userResponseDto.email());
+        Assertions.assertEquals(givenRequest.birthDay(),userResponseDto.birthDay());
+
+        verify(userRepository,times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("given_when_then 방식으로 deleteUser 서비스 성공 테스트")
+    void deleteUser() {
+        //given
+        User givenUser = User.builder()
+                .Id(1L)
+                .name("홍길순")
+                .loginId("kang4746")
+                .password("test1234")
+                .email("strong@gmail.com")
+                .birthDay("1999-10-29")
+                .build();
+
+        Mockito.when(userRepository.findById(1L))
+                .thenReturn(Optional.of(givenUser));
+        //when
+        userService.deleteUser(1L);
+
+        //then
+        verify(userRepository,times(1)).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("given_when_then 방식으로 updateUser 서비스 성공 테스트")
+    void updateUser() {
+        //given
+        User givenUser = User.builder()
+                .Id(1L)
+                .name("홍길순")
+                .loginId("kang4746")
+                .password("test1234")
+                .email("strong@gmail.com")
+                .birthDay("1999-10-29")
+                .build();
+
+        UserUpdateDto userUpdateDto = new UserUpdateDto("string","jun4746","strong@naver.com","string");
+        Mockito.when(userRepository.findById(1L))
+                .thenReturn(Optional.of(givenUser));
+        Mockito.when(userRepository.save(any(User.class)))
+                .then(returnsFirstArg());
+
+        //when
+        UserResponseDto userResponseDto = userService.updateUser(1L,userUpdateDto);
+
+        //then
+        Assertions.assertEquals(1L,userResponseDto.id());
+        Assertions.assertEquals("홍길순",userResponseDto.name());
+        Assertions.assertEquals("jun4746",userResponseDto.loginId());
+        Assertions.assertEquals("strong@naver.com",userResponseDto.email());
+        Assertions.assertEquals("1999-10-29",userResponseDto.birthDay());
+
+        verify(userRepository,times(1)).findById(1L);
+        verify(userRepository,times(1)).save(any());
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
close #14 
## 🛠 구현 사항
1. 유저 엔티티의 loginId 필드 오타를 수정하였습니다.
2. 유저 서비스 클래스에 조회, 회원가입, 수정, 삭제 메서드를 추가하였습니다.
3. 유저 reqeust, response, update dto를 추가하였습니다.
4. 유저 서비스 테스트 코드를 작성하였습니다.

## 📚 기타
