### PR TITLE
[Feat] 사진 조회기능, 사진 암호화 기능 생성

### DIFF
--- a/src/main/java/me/snaptime/snap/data/controller/PhotoController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/PhotoController.java
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,9 +21,12 @@ public class PhotoController {
 
     @Operation(summary = "Photo 조회", description = "조회할 Photo의 id를 입력해주세요")
     @GetMapping
-    public ResponseEntity<byte[]> findPhoto(final Long id) {
+    public ResponseEntity<byte[]> findPhoto(
+            final @RequestParam("id") Long id,
+            final @RequestParam("secretKey") String secretKey
+    ) {
         return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.IMAGE_PNG).body(
-                photoService.downloadPhotoFromFileSystem(id)
+                photoService.downloadPhotoFromFileSystem(id, secretKey)
         );
     }
 }

--- a/src/main/java/me/snaptime/snap/data/controller/PhotoController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/PhotoController.java
@@ -1,6 +1,8 @@
 package me.snaptime.snap.data.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.snap.service.PhotoService;
@@ -20,6 +22,10 @@ public class PhotoController {
     private final PhotoService photoService;
 
     @Operation(summary = "Photo 조회", description = "조회할 Photo의 id를 입력해주세요")
+    @Parameters({
+            @Parameter(name = "id", description = "찾을 사진의 id를 입력해주세요"),
+            @Parameter(name = "secretKey", description = "사용자의 AES 암호키를 입력해주세요")
+    })
     @GetMapping
     public ResponseEntity<byte[]> findPhoto(
             final @RequestParam("id") Long id,

--- a/src/main/java/me/snaptime/snap/data/controller/PhotoController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/PhotoController.java
@@ -1,8 +1,13 @@
 package me.snaptime.snap.data.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.snap.service.PhotoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "[Photo] Photo API")
 public class PhotoController {
     private final PhotoService photoService;
+
+    @Operation(summary = "Photo 조회", description = "조회할 Photo의 id를 입력해주세요")
+    @GetMapping
+    public ResponseEntity<byte[]> findPhoto(final Long id) {
+        return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.IMAGE_PNG).body(
+                photoService.downloadPhotoFromFileSystem(id)
+        );
+    }
 }

--- a/src/main/java/me/snaptime/snap/data/controller/SnapController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/SnapController.java
@@ -22,7 +22,7 @@ public class SnapController {
     @Operation(summary = "Snap 생성", description = "Empty Value를 보내지마세요")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<CommonResponseDto<?>> createSnap(final @ModelAttribute CreateSnapReqDto createSnapReqDto) {
-        snapService.createSnap(createSnapReqDto, null);
+        snapService.createSnap(createSnapReqDto, "test2");
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CommonResponseDto<>(
                 "스냅이 정상적으로 저장되었습니다.",

--- a/src/main/java/me/snaptime/snap/data/controller/SnapController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/SnapController.java
@@ -30,7 +30,7 @@ public class SnapController {
         ));
     }
 
-    @Operation(summary = "id로 Snap 찾기", description = "찾을 Snap의 id를 보내주세요")
+    @Operation(summary = "Snap 찾기", description = "찾을 Snap의 id를 보내주세요")
     @GetMapping
     public ResponseEntity<CommonResponseDto<FindSnapResDto>> findSnap(final Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(

--- a/src/main/java/me/snaptime/snap/data/controller/SnapController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/SnapController.java
@@ -1,6 +1,7 @@
 package me.snaptime.snap.data.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.common.dto.CommonResponseDto;
@@ -30,7 +31,8 @@ public class SnapController {
         ));
     }
 
-    @Operation(summary = "Snap 찾기", description = "찾을 Snap의 id를 보내주세요")
+    @Operation(summary = "Snap 찾기", description = "Snap 한 개 가져오기")
+    @Parameter(name = "id", description = "찾을 Snap의 id")
     @GetMapping("/{id}")
     public ResponseEntity<CommonResponseDto<FindSnapResDto>> findSnap(final @PathVariable("id") Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(

--- a/src/main/java/me/snaptime/snap/data/controller/SnapController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/SnapController.java
@@ -22,7 +22,7 @@ public class SnapController {
     @Operation(summary = "Snap 생성", description = "Empty Value를 보내지마세요")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<CommonResponseDto<?>> createSnap(final @ModelAttribute CreateSnapReqDto createSnapReqDto) {
-        snapService.createSnap(createSnapReqDto, "test2");
+        snapService.createSnap(createSnapReqDto, "abcd");
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CommonResponseDto<>(
                 "스냅이 정상적으로 저장되었습니다.",

--- a/src/main/java/me/snaptime/snap/data/controller/SnapController.java
+++ b/src/main/java/me/snaptime/snap/data/controller/SnapController.java
@@ -31,8 +31,8 @@ public class SnapController {
     }
 
     @Operation(summary = "Snap 찾기", description = "찾을 Snap의 id를 보내주세요")
-    @GetMapping
-    public ResponseEntity<CommonResponseDto<FindSnapResDto>> findSnap(final Long id) {
+    @GetMapping("/{id}")
+    public ResponseEntity<CommonResponseDto<FindSnapResDto>> findSnap(final @PathVariable("id") Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(
                 new CommonResponseDto<>(
                         "스냅이 정상적으로 불러와졌습니다.",

--- a/src/main/java/me/snaptime/snap/data/domain/Encryption.java
+++ b/src/main/java/me/snaptime/snap/data/domain/Encryption.java
@@ -1,0 +1,34 @@
+package me.snaptime.snap.data.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.snaptime.user.data.domain.User;
+
+import javax.crypto.SecretKey;
+
+@Entity
+@Getter
+@Table(name = "encryption")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Encryption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Column(nullable = false)
+    private SecretKey encryptionKey;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    protected Encryption(SecretKey encryptionKey, User user) {
+        this.encryptionKey = encryptionKey;
+        this.user = user;
+    }
+}

--- a/src/main/java/me/snaptime/snap/data/repository/EncryptionRepository.java
+++ b/src/main/java/me/snaptime/snap/data/repository/EncryptionRepository.java
@@ -1,0 +1,11 @@
+package me.snaptime.snap.data.repository;
+
+import me.snaptime.snap.data.domain.Encryption;
+import me.snaptime.user.data.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EncryptionRepository extends JpaRepository<Encryption, Long> {
+    Encryption findByUser(User user);
+}

--- a/src/main/java/me/snaptime/snap/service/PhotoService.java
+++ b/src/main/java/me/snaptime/snap/service/PhotoService.java
@@ -3,7 +3,9 @@ package me.snaptime.snap.service;
 import me.snaptime.snap.data.domain.Photo;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.crypto.SecretKey;
+
 public interface PhotoService {
-    Photo uploadPhotoToFileSystem(MultipartFile multipartFile);
-    byte[] downloadPhotoFromFileSystem(Long photoId);
+    Photo uploadPhotoToFileSystem(MultipartFile multipartFile, SecretKey secretKey);
+    byte[] downloadPhotoFromFileSystem(Long photoId, String secretKey);
 }

--- a/src/main/java/me/snaptime/snap/service/impl/PhotoServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/PhotoServiceImpl.java
@@ -7,14 +7,16 @@ import lombok.extern.slf4j.Slf4j;
 import me.snaptime.snap.data.domain.Photo;
 import me.snaptime.snap.data.repository.PhotoRepository;
 import me.snaptime.snap.service.PhotoService;
+import me.snaptime.snap.util.EncryptionUtil;
 import me.snaptime.snap.util.FileNameGenerator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.crypto.SecretKey;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Service
 @RequiredArgsConstructor
@@ -26,15 +28,15 @@ public class PhotoServiceImpl implements PhotoService {
     private String FOLDER_PATH;
 
     @Override
-    public Photo uploadPhotoToFileSystem(MultipartFile multipartFile) {
+    public Photo uploadPhotoToFileSystem(MultipartFile multipartFile, SecretKey secretKey) {
         String fileName = FileNameGenerator.generatorName(multipartFile.getOriginalFilename());
         String filePath = FOLDER_PATH + fileName;
         try {
-            multipartFile.transferTo(new File(filePath));
-        } catch (IOException e) {
+            byte[] encryptFile = EncryptionUtil.encryptData(multipartFile.getInputStream().readAllBytes(), secretKey);
+            Files.write(Paths.get(filePath), encryptFile);
+        } catch (Exception e) {
             log.error(e.getMessage());
         }
-
         return photoRepository.save(
                 Photo.builder()
                         .fileName(fileName)
@@ -45,12 +47,13 @@ public class PhotoServiceImpl implements PhotoService {
     }
 
     @Override
-    public byte[] downloadPhotoFromFileSystem(Long photoId) {
+    public byte[] downloadPhotoFromFileSystem(Long photoId, String secretKey) {
         Photo foundPhoto = photoRepository.findById(photoId).orElseThrow(() -> new EntityNotFoundException("id에 해당되는 사진을 찾을 수 없습니다."));
         String filePath = foundPhoto.getFilePath();
         try {
-            return Files.readAllBytes(new File(filePath).toPath());
-        } catch (IOException e) {
+            byte[] foundFile = Files.readAllBytes(new File(filePath).toPath());
+            return EncryptionUtil.decryptData(foundFile, secretKey);
+        } catch (Exception e) {
             byte[] emptyByte = {};
             log.error(e.getMessage());
             return emptyByte;

--- a/src/main/java/me/snaptime/snap/service/impl/SnapServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/SnapServiceImpl.java
@@ -2,36 +2,65 @@ package me.snaptime.snap.service.impl;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.snaptime.snap.data.domain.Encryption;
 import me.snaptime.snap.data.domain.Photo;
 import me.snaptime.snap.data.domain.Snap;
 import me.snaptime.snap.data.dto.req.CreateSnapReqDto;
 import me.snaptime.snap.data.dto.res.FindSnapResDto;
 import me.snaptime.snap.data.repository.AlbumRepository;
+import me.snaptime.snap.data.repository.EncryptionRepository;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.snap.service.PhotoService;
 import me.snaptime.snap.service.SnapService;
+import me.snaptime.snap.util.EncryptionUtil;
+import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.SecretKey;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SnapServiceImpl implements SnapService {
     private final PhotoService photoService;
     private final SnapRepository snapRepository;
     private final UserRepository userRepository;
     private final AlbumRepository albumRepository;
+    private final EncryptionRepository encryptionRepository;
 
     @Override
     public void createSnap(CreateSnapReqDto createSnapReqDto, String userUid) {
-       Photo savedPhoto = photoService.uploadPhotoToFileSystem(createSnapReqDto.multipartFile());
-       snapRepository.save(
-               Snap.builder()
-                       .oneLineJournal(createSnapReqDto.oneLineJournal())
-                       .photo(savedPhoto)
-                       .user(userRepository.findByLoginId(userUid))
-                       .album(albumRepository.findByName(createSnapReqDto.album()))
-                       .build()
-       );
+        User foundUser = userRepository.findByLoginId(userUid).orElseThrow(() -> new EntityNotFoundException("사용자가 요청한 uid를 가진 User를 찾을 수 없었습니다."));
+        try {
+            Encryption encryption = encryptionRepository.findByUser(foundUser);
+            if (encryption == null) {
+                // 사용자 암호화 키가 없다면 키 생성
+                SecretKey generatedKey = EncryptionUtil.generateAESKey();
+                // 암호화키 영속화
+                encryption = encryptionRepository.save(
+                        Encryption.builder()
+                                .encryptionKey(generatedKey)
+                                .user(foundUser)
+                                .build()
+                );
+            }
+            Photo savedPhoto = photoService.uploadPhotoToFileSystem(createSnapReqDto.multipartFile(), encryption.getEncryptionKey());
+            snapRepository.save(
+                    Snap.builder()
+                            .oneLineJournal(createSnapReqDto.oneLineJournal())
+                            .photo(savedPhoto)
+                            .user(foundUser)
+                            .album(albumRepository.findByName(createSnapReqDto.album()))
+                            .build()
+            );
+
+
+        } catch(Exception e)  {
+            log.error(e.getMessage());
+        }
+
     }
 
     @Override

--- a/src/main/java/me/snaptime/snap/util/EncryptionUtil.java
+++ b/src/main/java/me/snaptime/snap/util/EncryptionUtil.java
@@ -1,0 +1,37 @@
+package me.snaptime.snap.util;
+
+import javax.crypto.*;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class EncryptionUtil {
+    public static SecretKey generateAESKey() throws Exception {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+        keyGenerator.init(256);
+        return keyGenerator.generateKey();
+    }
+
+    public static byte[] encryptData(byte[] dataToEncrypt, SecretKey key) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        /*
+          Cipher 클래스는 JCA의 일부로 암호화 및 복호화 연산을 위한 기능을 제공한다.
+          Cipher 인스턴스는 getInstance(String algorithm) 메소드를 호출해 생성할 수 있다.
+          이 코드에서는 AES를 매개변수로 제공해 AES 암호화 알고리즘을 사용하는 Cipher 객체를 생성하고 있다.
+         */
+        Cipher cipher = Cipher.getInstance("AES");
+        // cipher 인스턴스를 암호화 모드로 초기화한다.
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        // doFinal 메소드를 호출해 암호화 연산을 완료한다.
+        return cipher.doFinal(dataToEncrypt);
+    }
+
+    public static byte[] decryptData(byte[] encryptedData, String key) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        byte[] decodedKey = Base64.getDecoder().decode(key);
+        SecretKey secretKey = new SecretKeySpec(decodedKey, 0, decodedKey.length, "AES");
+        Cipher cipher = Cipher.getInstance("AES");
+        cipher.init(Cipher.DECRYPT_MODE, secretKey);
+        return cipher.doFinal(encryptedData);
+    }
+
+}

--- a/src/main/java/me/snaptime/user/data/domain/User.java
+++ b/src/main/java/me/snaptime/user/data/domain/User.java
@@ -34,7 +34,6 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_birthDay",nullable = false)
     private String birthDay;
 
-
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private ProfilePhoto profilePhoto;
 

--- a/src/main/java/me/snaptime/user/data/repository/UserRepository.java
+++ b/src/main/java/me/snaptime/user/data/repository/UserRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User,Long> {
-    User findByLoginId(String loginId);
+    Optional<User> findByLoginId(String loginId);
     Optional<User> findUserByName(String name);
 }

--- a/src/test/java/me/snaptime/snap/controller/PhotoControllerTest.java
+++ b/src/test/java/me/snaptime/snap/controller/PhotoControllerTest.java
@@ -1,4 +1,55 @@
 package me.snaptime.snap.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.snaptime.snap.data.controller.PhotoController;
+import me.snaptime.snap.service.PhotoService;
+import me.snaptime.snap.util.EncryptionUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PhotoController.class)
 public class PhotoControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    PhotoService photoService;
+
+    private final Long givenId = 1L;
+
+    String testImagePath = "test_resource/image.jpg";
+    ClassPathResource resource = new ClassPathResource(testImagePath);
+
+    @DisplayName("Photo 가져오기 테스트")
+    @Test
+    public void findPhoto() throws Exception {
+        SecretKey secretKey = EncryptionUtil.generateAESKey();
+        String encodedKey = Base64.getEncoder().encodeToString(secretKey.getEncoded());
+        given(photoService.downloadPhotoFromFileSystem(givenId, encodedKey)).willReturn(
+                resource.getInputStream().readAllBytes()
+        );
+        mockMvc.perform(
+                get("/photo?id="+givenId+"&secretKey="+encodedKey)
+        ).andExpect(status().isOk())
+                .andDo(print());
+
+        verify(photoService).downloadPhotoFromFileSystem(givenId, encodedKey);
+    }
 }

--- a/src/test/java/me/snaptime/snap/controller/PhotoControllerTest.java
+++ b/src/test/java/me/snaptime/snap/controller/PhotoControllerTest.java
@@ -1,0 +1,4 @@
+package me.snaptime.snap.controller;
+
+public class PhotoControllerTest {
+}

--- a/src/test/java/me/snaptime/snap/controller/SnapControllerTest.java
+++ b/src/test/java/me/snaptime/snap/controller/SnapControllerTest.java
@@ -87,7 +87,7 @@ public class SnapControllerTest {
         FindSnapResDto findSnapResDto = FindSnapResDto.entityToResDto(expectedSnap);
         given(snapService.findSnap(1L)).willReturn(findSnapResDto);
         // when
-        mockMvc.perform(get("/snap?id=" + 1L))
+        mockMvc.perform(get("/snap/" + 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").exists())
                 .andExpect(jsonPath("$.result").exists())

--- a/src/test/java/me/snaptime/snap/controller/SnapControllerTest.java
+++ b/src/test/java/me/snaptime/snap/controller/SnapControllerTest.java
@@ -1,0 +1,4 @@
+package me.snaptime.snap.controller;
+
+public class SnapControllerTest {
+}

--- a/src/test/java/me/snaptime/snap/controller/SnapControllerTest.java
+++ b/src/test/java/me/snaptime/snap/controller/SnapControllerTest.java
@@ -1,4 +1,98 @@
 package me.snaptime.snap.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.snaptime.snap.data.controller.SnapController;
+import me.snaptime.snap.data.domain.Photo;
+import me.snaptime.snap.data.domain.Snap;
+import me.snaptime.snap.data.dto.req.CreateSnapReqDto;
+import me.snaptime.snap.data.dto.res.FindSnapResDto;
+import me.snaptime.snap.service.SnapService;
+import me.snaptime.user.data.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SnapController.class)
 public class SnapControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SnapService snapService;
+
+    String testImagePath = "test_resource/image.jpg";
+    ClassPathResource resource = new ClassPathResource(testImagePath);
+
+    @DisplayName("Snap 저장하기 테스트")
+    @Test
+    public void createSnapTest() throws Exception {
+        // given
+        MockMultipartFile multipartFile = new MockMultipartFile("name", "filename1.jpg", "image/png", resource.getInputStream().readAllBytes());
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("oneLineJournal", "한 줄 일기");
+        formData.add("album", "");
+        // when
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/snap")
+                        .file(multipartFile)
+                        .params(formData)
+        ).andExpect(status().isCreated())
+                .andDo(print());
+        // then
+        verify(snapService).createSnap(any(CreateSnapReqDto.class), eq("abcd"));
+    }
+
+    @DisplayName("Snap 가져오기 테스트")
+    @Test
+    public void findSnapTest() throws Exception {
+        // given
+        Snap expectedSnap = Snap.builder()
+                .id(1L)
+                .album(null)
+                .photo(Photo.builder()
+                        .fileName("파일 이름")
+                        .id(1L)
+                        .filePath("/path")
+                        .fileType("image/png")
+                        .build())
+                .user(User.builder()
+                        .Id(1L)
+                        .password("1234")
+                        .name("김원정")
+                        .email("test@test.com")
+                        .birthDay("990303")
+                        .loginId("test")
+                        .build())
+                .oneLineJournal("한 줄 일기")
+                .build();
+        FindSnapResDto findSnapResDto = FindSnapResDto.entityToResDto(expectedSnap);
+        given(snapService.findSnap(1L)).willReturn(findSnapResDto);
+        // when
+        mockMvc.perform(get("/snap?id=" + 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").exists())
+                .andExpect(jsonPath("$.result").exists())
+                .andDo(print());
+        // then
+        verify(snapService).findSnap(1L);
+    }
 }

--- a/src/test/java/me/snaptime/snap/service/PhotoServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/PhotoServiceImplTest.java
@@ -3,6 +3,7 @@ package me.snaptime.snap.service;
 import me.snaptime.snap.data.domain.Photo;
 import me.snaptime.snap.data.repository.PhotoRepository;
 import me.snaptime.snap.service.impl.PhotoServiceImpl;
+import me.snaptime.snap.util.EncryptionUtil;
 import me.snaptime.snap.util.FileNameGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,15 +15,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
+import javax.crypto.SecretKey;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-@ActiveProfiles
 public class PhotoServiceImplTest {
     @Mock
     private PhotoRepository photoRepository;
@@ -38,7 +38,7 @@ public class PhotoServiceImplTest {
 
     @DisplayName("사진 저장 테스트")
     @Test
-    public void uploadPhotoTest() throws IOException {
+    public void uploadPhotoTest() throws Exception {
         // given
         MultipartFile imageFile = new MockMultipartFile(
                 "image",
@@ -57,16 +57,18 @@ public class PhotoServiceImplTest {
                 .filePath(filePath)
                 .build();
 
+        SecretKey secretKey = EncryptionUtil.generateAESKey();
+
         given(photoRepository.save(Mockito.any(Photo.class))).willReturn(expectedPhoto);
 
-        /*// when
-        Photo result = photoServiceImpl.uploadPhotoToFileSystem(imageFile);
+        // when
+        Photo result = photoServiceImpl.uploadPhotoToFileSystem(imageFile, secretKey);
 
         // then
         assertEquals(expectedPhoto.getFileName(), result.getFileName());
         assertEquals(expectedPhoto.getFilePath(), result.getFilePath());
         assertEquals(expectedPhoto.getId(), result.getId());
-        assertEquals(expectedPhoto.getFileType(), result.getFileType());*/
+        assertEquals(expectedPhoto.getFileType(), result.getFileType());
 
     }
 

--- a/src/test/java/me/snaptime/snap/service/PhotoServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/PhotoServiceImplTest.java
@@ -19,7 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,14 +59,14 @@ public class PhotoServiceImplTest {
 
         given(photoRepository.save(Mockito.any(Photo.class))).willReturn(expectedPhoto);
 
-        // when
+        /*// when
         Photo result = photoServiceImpl.uploadPhotoToFileSystem(imageFile);
 
         // then
         assertEquals(expectedPhoto.getFileName(), result.getFileName());
         assertEquals(expectedPhoto.getFilePath(), result.getFilePath());
         assertEquals(expectedPhoto.getId(), result.getId());
-        assertEquals(expectedPhoto.getFileType(), result.getFileType());
+        assertEquals(expectedPhoto.getFileType(), result.getFileType());*/
 
     }
 

--- a/src/test/java/me/snaptime/snap/service/SnapServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/SnapServiceImplTest.java
@@ -1,32 +1,14 @@
 package me.snaptime.snap.service;
 
-import me.snaptime.snap.data.domain.Photo;
-import me.snaptime.snap.data.domain.Snap;
-import me.snaptime.snap.data.dto.req.CreateSnapReqDto;
-import me.snaptime.snap.data.dto.res.FindSnapResDto;
 import me.snaptime.snap.data.repository.AlbumRepository;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.snap.service.impl.SnapServiceImpl;
-import me.snaptime.snap.util.FileNameGenerator;
 import me.snaptime.user.data.repository.UserRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.Optional;
-
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 public class SnapServiceImplTest {
@@ -48,7 +30,7 @@ public class SnapServiceImplTest {
     String testImagePath = "test_resource/image.jpg";
     ClassPathResource resource = new ClassPathResource(testImagePath);
 
-    @DisplayName("스냅 저장 테스트")
+    /*@DisplayName("스냅 저장 테스트")
     @Test
     @Transactional
     public void createSnapTest() throws IOException {
@@ -124,5 +106,5 @@ public class SnapServiceImplTest {
         assertEquals(expectedDto.userUid(), result.userUid());
         assertEquals(expectedDto.photoId(), result.photoId());
         assertEquals(expectedDto.oneLineJournal(), result.oneLineJournal());
-    }
+    }*/
 }

--- a/src/test/java/me/snaptime/snap/service/SnapServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/SnapServiceImplTest.java
@@ -1,14 +1,35 @@
 package me.snaptime.snap.service;
 
+import me.snaptime.snap.data.domain.Encryption;
+import me.snaptime.snap.data.domain.Photo;
+import me.snaptime.snap.data.domain.Snap;
+import me.snaptime.snap.data.dto.req.CreateSnapReqDto;
+import me.snaptime.snap.data.dto.res.FindSnapResDto;
 import me.snaptime.snap.data.repository.AlbumRepository;
+import me.snaptime.snap.data.repository.EncryptionRepository;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.snap.service.impl.SnapServiceImpl;
+import me.snaptime.snap.util.EncryptionUtil;
+import me.snaptime.snap.util.FileNameGenerator;
+import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.crypto.SecretKey;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 public class SnapServiceImplTest {
@@ -24,16 +45,19 @@ public class SnapServiceImplTest {
     @Mock
     private AlbumRepository albumRepository;
 
+    @Mock
+    private EncryptionRepository encryptionRepository;
+
     @InjectMocks
     private SnapServiceImpl snapServiceImpl;
 
     String testImagePath = "test_resource/image.jpg";
     ClassPathResource resource = new ClassPathResource(testImagePath);
 
-    /*@DisplayName("스냅 저장 테스트")
+    @DisplayName("스냅 저장 테스트")
     @Test
     @Transactional
-    public void createSnapTest() throws IOException {
+    public void createSnapTest() throws Exception {
         // given
         MultipartFile givenMultipartFile = new MockMultipartFile(
                 "image",
@@ -55,15 +79,30 @@ public class SnapServiceImplTest {
                 .filePath("C:\\Image\\" + fileName)
                 .fileType(givenMultipartFile.getContentType())
                 .build();
-        given(photoService.uploadPhotoToFileSystem(givenMultipartFile)).willReturn(expectPhoto);
-        given(userRepository.findByLoginId(givenUid)).willReturn(null);
+        User expectedUser = User.builder()
+                .Id(1L)
+                .name("김원정")
+                .email("test@test.com")
+                .birthDay("990303")
+                .password("1234")
+                .build();
+        SecretKey secretKey = EncryptionUtil.generateAESKey();
+        given(photoService.uploadPhotoToFileSystem(givenMultipartFile, secretKey)).willReturn(expectPhoto);
+        given(userRepository.findByLoginId(givenUid)).willReturn(Optional.ofNullable(expectedUser));
         given(albumRepository.findByName(givenDto.album())).willReturn(null);
+        given(encryptionRepository.findByUser(expectedUser)).willReturn(null);
+        given(encryptionRepository.save(Mockito.any(Encryption.class))).willReturn(
+                Encryption.builder()
+                        .encryptionKey(secretKey)
+                        .user(expectedUser)
+                        .build()
+        );
         given(snapRepository.save(Mockito.any(Snap.class))).willReturn(
                 Snap.builder()
                         .id(1L)
                         .album(null)
                         .photo(expectPhoto)
-                .user(null)
+                .user(expectedUser)
                 .oneLineJournal(givenDto.oneLineJournal())
                 .build()
         );
@@ -106,5 +145,5 @@ public class SnapServiceImplTest {
         assertEquals(expectedDto.userUid(), result.userUid());
         assertEquals(expectedDto.photoId(), result.photoId());
         assertEquals(expectedDto.oneLineJournal(), result.oneLineJournal());
-    }*/
+    }
 }


### PR DESCRIPTION
## 📋 이슈 번호
close #17 

## 🛠 구현 사항
사진을 조회할 수 있는 end-point와 사진을 암호화하여 안전하게 저장해둘 수 있는 기능을 개발했습니다.
사진은 양방향 대칭키인 AES로 암호화되어 서버에 저장됩니다. 암호화키는 User와 1:1관계로 매핑된 Encryption 테이블에 User 정보와 함께 저장됩니다. 암호화키가 유출될 수도 있는 상황을 고려해 코드내에서 SecretKey를 encode하여 읽는 로직은 배제하였고, DB에 영속화 할 때도 Row Value를 다루는 일 없이 클래스 자체를 영속화 해 한번 더 난독화 될 수 있게 했습니다.

앞으로는 Photo를 넘어 Snap의 한 줄 일기도 암호화하여 저장하는 기능을 개발하는 것이 목표입니다. 

## 📚 기타
몇가지 생각하고 넘어가야 할 부분이 있습니다.

**첫번째로는 현재 구현한 암호화 방식이 올바른가? 입니다.** 
지금 구현된 방식은 서버에서 생성된 암호화키를 DB에 저장하는 방식인데, 이 방식은 서버가 사용자의 암호화키를 알고 있다는 문제가 있습니다. 이렇게 한 이유는 프론트가 키를 관리하는 것은 어렵다고 생각했기 때문입니다. 왜냐면 암호화키를 분실할 시 사용자가 그동안 올렸던 모든 파일에 대한 접근권한을 잃어버릴 수 있게 되기 때문입니다. 그렇기 때문에 이러한 방식을 택하였고 서버가 사용자의 암호키를 알고있다는 문제를 해결하기 위해서 코드를 난독화하여 DB에 저장하였는데... 여전히 이 접근 방식이 올바른가에 대한 의문이 남아있습니다. 이 접근 방법이 잘못됐다거나 더 좋은 방법이 있을 경우 코멘트 부탁드리겠습니다.

**사진과 같은 데이터를 다루는 서비스와 컨트롤러의 테스트가 까다롭습니다.** 
특히 저장된 사진을 불러오는 테스트가 구현이 어려운데 이를 어떻게 해야 좋게 구현할 수 있을지 고민입니다.
저장된 사진을 불러오는 테스트가 구현이 어려운 이유는 개발 환경과 테스트 환경이 다르기 때문인데,
현재 downloadPhoto... 메소드가 Profile(Properties)에 의존하여 경로를 가져오고 있기 때문입니다.
테스트 환경.. 그러니깐 Github Actions 환경과 개발 환경, 배포환경 전부 경로가 다르다 보니 일관된 테스트가 어려운데...
이런 문제를 여러 Profiles로 해결하려고 고민하고 있습니다만, 코드로 개선할 수 있다면 코드로 개선하고 싶습니다. 이를 어떻게 하면 좋을지 고민입니다.
