### PR TITLE
[Feat,Refactor] User,ProfilePhoto 컨트롤러, 서비스 추가

### DIFF
--- a/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
+++ b/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
@@ -12,7 +12,11 @@ public enum ExceptionCode {
     ALREADY_FOLLOW(HttpStatus.BAD_REQUEST,"이미 팔로우관계입니다."),
     FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 친구입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 유저입니다."),
-    ACCESS_FAIL_FRIENDSHIP(HttpStatus.FORBIDDEN,"해당 친구에 대한 권한이 없습니다.");
+    ACCESS_FAIL_FRIENDSHIP(HttpStatus.FORBIDDEN,"해당 친구에 대한 권한이 없습니다."),
+
+    // ProfilePhotoException
+    FILE_NOT_EXIST(HttpStatus.NOT_FOUND,"해당하는 경로에 파일이 존재하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/me/snaptime/user/data/controller/ProfilePhotoController.java
+++ b/src/main/java/me/snaptime/user/data/controller/ProfilePhotoController.java
@@ -1,0 +1,83 @@
+package me.snaptime.user.data.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.snaptime.common.dto.CommonResponseDto;
+import me.snaptime.user.data.dto.response.ProfilePhotoResponseDto;
+import me.snaptime.user.service.ProfilePhotoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.apache.tomcat.util.http.fileupload.FileUploadBase.MULTIPART_FORM_DATA;
+
+@Tag(name ="[ProfilePhoto] ProfilePhoto API", description = "프로필 사진 생성, 프로필 사진 조회, 프로필 사진 수정, 프로필 사진 삭제")
+@Slf4j
+@RestController
+@RequestMapping("/profilePhotos")
+@RequiredArgsConstructor
+public class ProfilePhotoController {
+
+    private final ProfilePhotoService profilePhotoService;
+
+    @Operation(summary = "프로필 사진 업로드",description = "유저의 프로필 사진을 업로드 합니다.")
+    @Parameter(name = "userId", description = "프로필 사진을 업로드 할 유저 id")
+    @PostMapping(consumes = MULTIPART_FORM_DATA)
+    public ResponseEntity<?> uploadProfileToFileSystem(@RequestParam("userId") Long userId, @RequestParam("imageFile") MultipartFile imageFile) throws Exception {
+        log.info("[uploadProfile] 유저의 프로필 사진을 업로드합니다. userId : {}",userId);
+
+        ProfilePhotoResponseDto uploadProfile = profilePhotoService.uploadPhotoToFileSystem(userId, imageFile);
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                new CommonResponseDto<>(
+                        "프로필 사진 생성을 성공적으로 완료하였습니다.",
+                        uploadProfile)
+        );
+    }
+
+    @Operation(summary = "프로필 사진 조회",description = "유저의 프로필 사진을 조회 합니다.")
+    @Parameter(name = "profilePhotoId",description = "조회 할 프로필 사진의 id")
+    @GetMapping()
+    public ResponseEntity<?> downloadProfileToFileSystem(@PathVariable("profilePhotoId") Long profilePhotoId) {
+        log.info("[downloadProfile] 유저의 프로필 사진을 조회합니다.");
+
+        byte[] downloadProfile = profilePhotoService.downloadPhotoFromFileSystem(profilePhotoId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.valueOf("image/png"))
+                .body(downloadProfile);
+    }
+
+    @Operation(summary = "프로필 사진 수정",description = "유저의 프로필 사진을 수정 합니다.")
+    @Parameter(name = "userId", description = "프로필 사진을 수정 할 유저 id")
+    @PutMapping(consumes = MULTIPART_FORM_DATA, path = "/update")
+    public ResponseEntity<?> updateProfileToFileSystem(@RequestParam("userId") Long userId, @RequestParam("image") MultipartFile file) throws Exception {
+        log.info("[updateProfile] 유저의 프로필 사진을 수정합니다. userId : {}",userId);
+        ProfilePhotoResponseDto updateProfile = profilePhotoService.updatePhotoFromFileSystem(userId, file);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CommonResponseDto<>(
+                        "프로필 사진 수정을 성공적으로 완료하였습니다.",
+                        updateProfile)
+        );
+    }
+
+    @Operation(summary = "프로필 사진 삭제",description = "유저의 프로필 사진을 삭제 합니다.")
+    @Parameter(name = "userId", description = "프로필 사진을 삭제할 유저의 id")
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<?> deleteProfileToFileSystem(@PathVariable("userId") Long userId)throws Exception{
+        log.info("[deleteProfile] 유저의 프로필 사진을 삭제합니다. userId : {}", userId);
+        profilePhotoService.deletePhotoFromFileSystem(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CommonResponseDto<>(
+                        "프로필 사진 삭제를 성공적으로 완료하였습니다.",
+                        null)
+        );
+    }
+
+
+
+}

--- a/src/main/java/me/snaptime/user/data/controller/UserController.java
+++ b/src/main/java/me/snaptime/user/data/controller/UserController.java
@@ -1,0 +1,82 @@
+package me.snaptime.user.data.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.snaptime.common.dto.CommonResponseDto;
+import me.snaptime.user.data.dto.request.UserRequestDto;
+import me.snaptime.user.data.dto.request.UserUpdateDto;
+import me.snaptime.user.data.dto.response.UserResponseDto;
+import me.snaptime.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name ="[User] User API", description = "유저 생성,유저 조회, 유저 수정, 유저 삭제")
+@Slf4j
+@RequestMapping("/users")
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+
+    @Operation(summary = "유저 정보 조회",description = "유저 번호로 유저를 조회합니다.")
+    @Parameter(name = "userId", description = "찾을 유저의 id")
+    @GetMapping("/{userId}")
+    public ResponseEntity<CommonResponseDto<UserResponseDto>> getUser(final @PathVariable("userId") Long userId){
+        log.info("[getUser] 유저 id로 유저 정보를 가져옵니다. uid : {}",userId);
+        UserResponseDto userResponseDto = userService.getUser(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CommonResponseDto<>(
+                        "유저 정보가 성공적으로 조회되었습니다.",
+                        userResponseDto));
+    }
+
+
+    @Operation(summary = "유저 정보 수정",description = "유저 번호로 해당 유저의 정보를 수정합니다.")
+    @Parameter(name = "userId", description = "수정할 유저의 id")
+    @PutMapping("/{userId}")
+    public ResponseEntity<CommonResponseDto<UserResponseDto>> changeUser(@PathVariable("userId") Long userId
+            , @RequestBody UserUpdateDto userUpdateDto){
+        log.info("[changeUser] 유저의 정보를 수정합니다. uid : {}",userId);
+        UserResponseDto userResponseDto = userService.updateUser(userId,userUpdateDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CommonResponseDto<>(
+                        "유저 정보 수정이 성공적으로 완료되었습니다.",
+                        userResponseDto));
+    }
+
+    @Operation(summary = "유저 삭제",description = "유저 번호로 유저를 삭제합니다.")
+    @Parameter(name = "userId", description = "삭제할 유저의 id")
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<CommonResponseDto<Void>> deleteUser(@PathVariable("userId") Long userId){
+        log.info("[deleteUser] 유저를 삭제합니다. uid : {}", userId);
+        userService.deleteUser(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CommonResponseDto<>(
+                        "유저 삭제가 성공적으로 완료되었습니다.",
+                        null));
+    }
+
+    @Operation(summary = "회원가입", description = "회원 가입 할 유저의 정보를 입력합니다.")
+    @PostMapping("/sign-up")
+    public ResponseEntity<CommonResponseDto<UserResponseDto>> signUp(@RequestBody UserRequestDto userRequestDto){
+        String role = "USER";
+        log.info("[signUp] 회원가입을 수행합니다. loginId : {}, password : ****, name : {}, email : {}, birthDay : {}",userRequestDto.loginId(),userRequestDto.name(),userRequestDto.email(),userRequestDto.birthDay());
+
+        UserResponseDto userResponseDto = userService.signUp(userRequestDto);
+
+        log.info("[signUp] 회원가입을 완료했습니다. id : {}",userResponseDto.loginId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                new CommonResponseDto<>(
+                        "유저 회원가입을 성공적으로 완료하였습니다.",
+                        userResponseDto));
+    }
+}

--- a/src/main/java/me/snaptime/user/data/domain/ProfilePhoto.java
+++ b/src/main/java/me/snaptime/user/data/domain/ProfilePhoto.java
@@ -37,5 +37,9 @@ public class ProfilePhoto extends BaseTimeEntity {
         this.user = user;
     }
 
-
+    public void updateProfile(String profilePhotoName,String profilePhotoPath)
+    {
+        this.profilePhotoName = profilePhotoName;
+        this.profilePhotoPath = profilePhotoPath;
+    }
 }

--- a/src/main/java/me/snaptime/user/data/dto/request/ProfilePhotoRequestDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/request/ProfilePhotoRequestDto.java
@@ -1,0 +1,21 @@
+package me.snaptime.user.data.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record ProfilePhotoRequestDto(
+        @Schema(
+                example = "형준프로필",
+                description = "프로필 사진 이름을 입력해주세요"
+        )
+        @NotBlank(message = "프로필 사진 입력은 필수입니다.")
+        String profilePhotoName,
+        @Schema(
+                example = "https://...",
+                description = "프로필 경로를 입력해주세요"
+        )
+        @NotBlank(message = "프로필 사진 경로 입력은 필수입니다.")
+        String profilePhotoPath
+){}

--- a/src/main/java/me/snaptime/user/data/dto/request/UserRequestDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/request/UserRequestDto.java
@@ -2,7 +2,9 @@ package me.snaptime.user.data.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UserRequestDto(
         @Schema(
                 example = "홍길순",

--- a/src/main/java/me/snaptime/user/data/dto/request/UserUpdateDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/request/UserUpdateDto.java
@@ -2,7 +2,9 @@ package me.snaptime.user.data.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UserUpdateDto(
         @Schema(
                 example = "홍길순",

--- a/src/main/java/me/snaptime/user/data/dto/response/ProfilePhotoResponseDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/response/ProfilePhotoResponseDto.java
@@ -1,0 +1,21 @@
+package me.snaptime.user.data.dto.response;
+
+import lombok.Builder;
+import me.snaptime.user.data.domain.ProfilePhoto;
+
+@Builder
+public record ProfilePhotoResponseDto(
+        Long id,
+        Long userId,
+        String profilePhotoName,
+        String profilePhotoPath
+){
+    public static ProfilePhotoResponseDto toDto(ProfilePhoto profilePhoto){
+        return ProfilePhotoResponseDto.builder()
+                .id(profilePhoto.getId())
+                .userId(profilePhoto.getUser().getId())
+                .profilePhotoName(profilePhoto.getProfilePhotoName())
+                .profilePhotoPath(profilePhoto.getProfilePhotoPath())
+                .build();
+    }
+}

--- a/src/main/java/me/snaptime/user/data/repository/ProfilePhotoRepository.java
+++ b/src/main/java/me/snaptime/user/data/repository/ProfilePhotoRepository.java
@@ -1,10 +1,15 @@
 package me.snaptime.user.data.repository;
 
 import me.snaptime.user.data.domain.ProfilePhoto;
+import me.snaptime.user.data.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ProfilePhotoRepository extends JpaRepository<ProfilePhoto,Long>{
+    Optional<ProfilePhoto> findProfilePhotoByUser(User user);
+
 }

--- a/src/main/java/me/snaptime/user/service/ProfilePhotoService.java
+++ b/src/main/java/me/snaptime/user/service/ProfilePhotoService.java
@@ -8,6 +8,7 @@ import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.dto.response.ProfilePhotoResponseDto;
 import me.snaptime.user.data.repository.ProfilePhotoRepository;
 import me.snaptime.user.data.repository.UserRepository;
+import me.snaptime.user.util.ProfilePhotoNameGenerator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +35,7 @@ public class ProfilePhotoService {
     @Transactional
     public ProfilePhotoResponseDto uploadPhotoToFileSystem(Long userId, MultipartFile uploadFile) throws Exception{
         User createUser = userRepository.findById(userId).orElseThrow(()-> new NoSuchElementException("프로필 사진을 업로드 할 유저가 존재하지 않습니다."));
-        String fileName = FileNameGenerator.generatorName(uploadFile.getOriginalFilename());
+        String fileName = ProfilePhotoNameGenerator.generatorProfilePhotoName(uploadFile.getOriginalFilename());
         String filePath = FOLDER_PATH + fileName;
 
         try{
@@ -88,7 +89,7 @@ public class ProfilePhotoService {
         User updateUser = userRepository.findById(userId).orElseThrow(()-> new NoSuchElementException("수정 할 유저가 존재하지 않습니다."));
         ProfilePhoto profilePhoto = profilePhotoRepository.findProfilePhotoByUser(updateUser).orElseThrow(()-> new NoSuchElementException("수정 할 프로필 사진이 없습니다."));
 
-        String updateFileName = FileNameGenerator.generatorName(updateFile.getOriginalFilename());
+        String updateFileName = ProfilePhotoNameGenerator.generatorProfilePhotoName(updateFile.getOriginalFilename());
         String updateFilePath = FOLDER_PATH + updateFileName;
 
         try{

--- a/src/main/java/me/snaptime/user/service/ProfilePhotoService.java
+++ b/src/main/java/me/snaptime/user/service/ProfilePhotoService.java
@@ -1,0 +1,107 @@
+package me.snaptime.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.snaptime.snap.util.FileNameGenerator;
+import me.snaptime.user.data.domain.ProfilePhoto;
+import me.snaptime.user.data.domain.User;
+import me.snaptime.user.data.dto.response.ProfilePhotoResponseDto;
+import me.snaptime.user.data.repository.ProfilePhotoRepository;
+import me.snaptime.user.data.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ProfilePhotoService {
+
+    private final UserRepository userRepository;
+    private final ProfilePhotoRepository profilePhotoRepository;
+
+    @Value("${fileSystemPath}")
+    private String FOLDER_PATH;
+
+    @Transactional
+    public ProfilePhotoResponseDto uploadPhotoToFileSystem(Long userId, MultipartFile uploadFile) throws Exception{
+        User createUser = userRepository.findById(userId).orElseThrow(()-> new NoSuchElementException("프로필 사진을 업로드 할 유저가 존재하지 않습니다."));
+        String fileName = FileNameGenerator.generatorName(uploadFile.getOriginalFilename());
+        String filePath = FOLDER_PATH + fileName;
+
+        try{
+            uploadFile.transferTo(new File(filePath));
+        }catch (IOException e){
+            log.error(e.getMessage());
+        }
+
+        return ProfilePhotoResponseDto.toDto(profilePhotoRepository.save(
+                ProfilePhoto.builder()
+                        .profilePhotoName(fileName)
+                        .profilePhotoPath(filePath)
+                        .user(createUser)
+                        .build()));
+    }
+
+
+    public byte[] downloadPhotoFromFileSystem(Long id){
+        ProfilePhoto profilePhoto = profilePhotoRepository.findById(id).orElseThrow(()->new NoSuchElementException("해당하는 id의 프로필 사진을 찾을 수 없습니다."));
+        String filePath = profilePhoto.getProfilePhotoPath();
+
+        try{
+            return Files.readAllBytes(new File(filePath).toPath());
+        }catch (IOException e){
+            byte[] emptyByte = {};
+            log.error(e.getMessage());
+            return emptyByte;
+        }
+    }
+
+
+    public void deletePhotoFromFileSystem(Long userId) throws Exception{
+        User deleteUser = userRepository.findById(userId).orElseThrow(()-> new NoSuchElementException("삭제 할 유저가 존재하지 않습니다."));
+        ProfilePhoto profilePhoto = profilePhotoRepository.findProfilePhotoByUser(deleteUser).orElseThrow(()-> new NoSuchElementException("해당하는 프로필 사진이 존재하지 않습니다."));
+        profilePhotoRepository.deleteById(profilePhoto.getId());
+
+        String photoPath = profilePhoto.getProfilePhotoPath();
+        if(!photoPath.isEmpty()){
+            try{
+                Path path = Paths.get(photoPath);
+                Files.deleteIfExists(path);
+            }catch (Exception e){
+                e.printStackTrace();
+                throw new Exception("프로필 사진 파일 삭제를 실패하였습니다.");
+            }
+        }
+    }
+
+    @Transactional
+    public ProfilePhotoResponseDto updatePhotoFromFileSystem(Long userId, MultipartFile updateFile) throws Exception{
+        User updateUser = userRepository.findById(userId).orElseThrow(()-> new NoSuchElementException("수정 할 유저가 존재하지 않습니다."));
+        ProfilePhoto profilePhoto = profilePhotoRepository.findProfilePhotoByUser(updateUser).orElseThrow(()-> new NoSuchElementException("수정 할 프로필 사진이 없습니다."));
+
+        String updateFileName = FileNameGenerator.generatorName(updateFile.getOriginalFilename());
+        String updateFilePath = FOLDER_PATH + updateFileName;
+
+        try{
+            Path path = Paths.get(profilePhoto.getProfilePhotoPath());
+            Files.deleteIfExists(path);
+            updateFile.transferTo(new File(updateFilePath));
+        }catch (IOException e){
+            log.error(e.getMessage());
+        }
+
+        profilePhoto.updateProfile(updateFileName,updateFilePath);
+
+        return ProfilePhotoResponseDto.toDto(profilePhotoRepository.save(profilePhoto));
+    }
+
+}

--- a/src/main/java/me/snaptime/user/service/UserService.java
+++ b/src/main/java/me/snaptime/user/service/UserService.java
@@ -3,6 +3,8 @@ package me.snaptime.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.snaptime.common.exception.customs.CustomException;
+import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.dto.request.UserRequestDto;
 import me.snaptime.user.data.dto.request.UserUpdateDto;
@@ -11,7 +13,6 @@ import me.snaptime.user.data.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,11 +23,12 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserResponseDto getUser(Long id){
-        User user = userRepository.findById(id).orElseThrow(()-> new NoSuchElementException("해당 로그인 아이드의 유저를 찾을 수 없습니다."));
+        User user = userRepository.findById(id).orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_FOUND));
 
         return UserResponseDto.toDto(user);
     }
 
+    @Transactional
     public UserResponseDto signUp(UserRequestDto userRequestDto){
 
         User user = User.builder()
@@ -41,14 +43,16 @@ public class UserService {
         return UserResponseDto.toDto(userRepository.save(user));
     }
 
+    @Transactional
     public void deleteUser(Long id){
-        User user = userRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당 id의 유저가 존재하지 않습니다."));
+        User user = userRepository.findById(id).orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_FOUND));
         userRepository.deleteById(user.getId());
     }
 
+    @Transactional
     public UserResponseDto updateUser(Long id, UserUpdateDto userUpdateDto){
 
-        User user = userRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당 loginId의 유저가 존재하지 않습니다."));
+        User user = userRepository.findById(id).orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_FOUND));
 
         if (userUpdateDto.name() !=null && !userUpdateDto.name().isEmpty() && !userUpdateDto.name().equals("string")){
             user.updateUserName(userUpdateDto.name());

--- a/src/main/java/me/snaptime/user/util/ProfilePhotoNameGenerator.java
+++ b/src/main/java/me/snaptime/user/util/ProfilePhotoNameGenerator.java
@@ -1,0 +1,12 @@
+package me.snaptime.user.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ProfilePhotoNameGenerator {
+    static String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMddHHmmssSSS"));
+
+    public static String generatorProfilePhotoName(String fileName) {
+        return currentTime + fileName;
+    }
+}

--- a/src/test/java/me/snaptime/user/controller/ProfilePhotoControllerTest.java
+++ b/src/test/java/me/snaptime/user/controller/ProfilePhotoControllerTest.java
@@ -1,0 +1,31 @@
+package me.snaptime.user.controller;
+
+
+import me.snaptime.user.data.domain.ProfilePhoto;
+import me.snaptime.user.service.ProfilePhotoService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProfilePhoto.class)
+public class ProfilePhotoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    ProfilePhotoService profilePhotoService;
+
+    @Test
+    @DisplayName("프로필 사진 업로드 컨트롤러 테스트")
+    public void uploadProfileToFileSystemTest() throws Exception {
+
+    }
+
+
+
+
+}

--- a/src/test/java/me/snaptime/user/controller/UserControllerTest.java
+++ b/src/test/java/me/snaptime/user/controller/UserControllerTest.java
@@ -32,6 +32,7 @@ public class UserControllerTest {
     @MockBean
     UserService userService;
 
+
     @Test
     @DisplayName("유저 정보 조회 컨트롤러 테스트")
     void getUserTest() throws Exception{

--- a/src/test/java/me/snaptime/user/controller/UserControllerTest.java
+++ b/src/test/java/me/snaptime/user/controller/UserControllerTest.java
@@ -1,0 +1,161 @@
+package me.snaptime.user.controller;
+
+import com.google.gson.Gson;
+import me.snaptime.user.data.controller.UserController;
+import me.snaptime.user.data.dto.request.UserRequestDto;
+import me.snaptime.user.data.dto.request.UserUpdateDto;
+import me.snaptime.user.data.dto.response.UserResponseDto;
+import me.snaptime.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    UserService userService;
+
+    @Test
+    @DisplayName("유저 정보 조회 컨트롤러 테스트")
+    void getUserTest() throws Exception{
+
+        //given
+        given(userService.getUser(1L)).willReturn(
+                UserResponseDto.builder()
+                        .id(1L)
+                        .loginId("kang4746")
+                        .password("test1234")
+                        .email("strong@gmail.com")
+                        .birthDay("1999-10-29")
+                        .build());
+
+        //when
+        Long userId = 1L;
+        mockMvc.perform(get("/users/{userId}",1L))
+                        .andExpect(status().isOk())
+                        //json response 형식을 잘 봅시다.
+                        .andExpect(jsonPath("$.msg").exists())
+                        .andExpect(jsonPath("$.result.id").exists())
+                        .andExpect(jsonPath("$.result.loginId").exists())
+                        .andExpect(jsonPath("$.result.password").exists())
+                        .andExpect(jsonPath("$.result.email").exists())
+                        .andExpect(jsonPath("$.result.birthDay").exists())
+                        .andDo(print());
+
+        //then
+        verify(userService).getUser(1L);
+    }
+
+    @Test
+    @DisplayName("유저 회원가입 컨트롤러 테스트")
+    void signUpTest() throws Exception{
+
+        //given
+        UserRequestDto userRequestDto = UserRequestDto.builder()
+                .loginId("kang4746")
+                .password("test1234")
+                .name("홍길순")
+                .email("strong@gmail.com")
+                .birthDay("1999-10-29")
+                .build();
+
+        given(userService.signUp(any(UserRequestDto.class)))
+                .willReturn(UserResponseDto.builder()
+                        .id(1L)
+                        .loginId("kang4746")
+                        .password("test1234")
+                        .name("홍길순")
+                        .email("strong@gmail.com")
+                        .birthDay("1999-10-29")
+                        .build());
+
+        Gson gson = new Gson();
+        String content = gson.toJson(userRequestDto);
+
+        //when
+        mockMvc.perform(post("/users/sign-up").content(content).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.msg").exists())
+                .andExpect(jsonPath("$.result.id").exists())
+                .andExpect(jsonPath("$.result.loginId").exists())
+                .andExpect(jsonPath("$.result.password").exists())
+                .andExpect(jsonPath("$.result.email").exists())
+                .andExpect(jsonPath("$.result.birthDay").exists())
+                .andDo(print());
+
+        //then
+        verify(userService).signUp(any(UserRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("유저 수정 테스트")
+    void updateUserTest() throws Exception{
+
+        //given
+        UserUpdateDto userUpdateDto = UserUpdateDto.builder()
+                .loginId("jun4746")
+                .name("")
+                .email("strong@naver.com")
+                .birthDay("")
+                .build();
+
+        given(userService.updateUser(eq(1L),any(UserUpdateDto.class)))
+                .willReturn(UserResponseDto.builder()
+                        .id(1L)
+                        .loginId("kang4746")
+                        .password("test1234")
+                        .name("홍길순")
+                        .email("strong@gmail.com")
+                        .birthDay("1999-10-29")
+                        .build());
+
+        Gson gson = new Gson();
+        String content = gson.toJson(userUpdateDto);
+
+        //when
+        Long userId = 1L;
+        mockMvc.perform(put("/users/{userId}",userId)
+                .content(content).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.msg").exists())
+                .andExpect(jsonPath("$.result.id").exists())
+                .andExpect(jsonPath("$.result.loginId").exists())
+                .andExpect(jsonPath("$.result.password").exists())
+                .andExpect(jsonPath("$.result.email").exists())
+                .andExpect(jsonPath("$.result.birthDay").exists())
+                .andDo(print());
+
+        //then
+        verify(userService).updateUser(eq(1L),any(UserUpdateDto.class));
+    }
+
+    @Test
+    @DisplayName("유저 삭제 테스트")
+    void deleteUserTest() throws Exception{
+        //given
+        //when
+        Long userId = 1L;
+        mockMvc.perform(delete("/users/{userId}",userId))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(userService).deleteUser(1L);
+    }
+
+}

--- a/src/test/java/me/snaptime/user/service/ProfilePhotoServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/ProfilePhotoServiceTest.java
@@ -6,6 +6,7 @@ import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.dto.response.ProfilePhotoResponseDto;
 import me.snaptime.user.data.repository.ProfilePhotoRepository;
 import me.snaptime.user.data.repository.UserRepository;
+import me.snaptime.user.util.ProfilePhotoNameGenerator;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -69,7 +70,7 @@ public class ProfilePhotoServiceTest {
                 "profile/jpeg",
                 new byte[]{});
 
-        String fileName = FileNameGenerator.generatorName(uploadFile.getOriginalFilename());
+        String fileName = ProfilePhotoNameGenerator.generatorProfilePhotoName(uploadFile.getOriginalFilename());
         String filePath = FOLDER_PATH + fileName;
 
         ProfilePhoto givenProfilePhoto = ProfilePhoto.builder()
@@ -114,7 +115,7 @@ public class ProfilePhotoServiceTest {
                 "profile/jpeg",
                 new byte[]{});
 
-        String fileName = FileNameGenerator.generatorName(updateFile.getOriginalFilename());
+        String fileName = ProfilePhotoNameGenerator.generatorProfilePhotoName(updateFile.getOriginalFilename());
         String filePath = FOLDER_PATH + fileName;
 
         /*업데이트 할 프로필 사진*/

--- a/src/test/java/me/snaptime/user/service/ProfilePhotoServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/ProfilePhotoServiceTest.java
@@ -1,0 +1,194 @@
+package me.snaptime.user.service;
+
+import me.snaptime.snap.util.FileNameGenerator;
+import me.snaptime.user.data.domain.ProfilePhoto;
+import me.snaptime.user.data.domain.User;
+import me.snaptime.user.data.dto.response.ProfilePhotoResponseDto;
+import me.snaptime.user.data.repository.ProfilePhotoRepository;
+import me.snaptime.user.data.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProfilePhotoServiceTest {
+
+    private UserRepository userRepository = Mockito.mock(UserRepository.class);
+    private ProfilePhotoRepository profilePhotoRepository = Mockito.mock(ProfilePhotoRepository.class);
+    private ProfilePhotoService profilePhotoService;
+
+    private String deleteFilePath;
+    private User givenUser;
+
+    private String FOLDER_PATH = "C:\\Image\\";
+
+    @BeforeEach
+    public void setUpTest(){
+        profilePhotoService = new ProfilePhotoService(userRepository,profilePhotoRepository);
+        givenUser =  User.builder()
+                .Id(1L)
+                .name("홍길순")
+                .loginId("kang4746")
+                .password("test1234")
+                .email("strong@gmail.com")
+                .birthDay("1999-10-29")
+                .build();
+    }
+
+    //테스트 코드 실행 후, root 폴더에 null+생성시간 파일이 생성됨
+    @AfterEach
+    public void deleteFile(){
+        File file = new File(deleteFilePath);
+
+        if(file.exists()){
+            file.delete();
+        }
+    }
+
+    @Test
+    @DisplayName("given_when_then 방식으로 프로필 사진 upload 서비스 성공 테스트")
+    void uploadPhotoToFileSystemTest() throws Exception {
+        //given
+        /*mock객체로 upload할 파일 생성*/
+        MultipartFile uploadFile = new MockMultipartFile(
+                "profile",
+                "profile",
+                "profile/jpeg",
+                new byte[]{});
+
+        String fileName = FileNameGenerator.generatorName(uploadFile.getOriginalFilename());
+        String filePath = FOLDER_PATH + fileName;
+
+        ProfilePhoto givenProfilePhoto = ProfilePhoto.builder()
+                .Id(1L)
+                .user(givenUser)
+                .profilePhotoName(uploadFile.getOriginalFilename())
+                .profilePhotoPath(filePath)
+                .build();
+
+        Long uploadUserId = 1L;
+        /*업로드를 위한 유저 조회*/
+        Mockito.when(userRepository.findById(uploadUserId))
+                .thenReturn(Optional.of(givenUser));
+        /*프로필 저장*/
+        Mockito.when(profilePhotoRepository.save(any(ProfilePhoto.class)))
+                .thenReturn(givenProfilePhoto);
+
+        //when
+        ProfilePhotoResponseDto responseDto = profilePhotoService.uploadPhotoToFileSystem(uploadUserId, uploadFile);
+
+        //then
+        Assertions.assertEquals(givenProfilePhoto.getProfilePhotoName(),responseDto.profilePhotoName());
+        Assertions.assertEquals(givenProfilePhoto.getProfilePhotoPath(),responseDto.profilePhotoPath());
+        Assertions.assertEquals(givenProfilePhoto.getUser().getId(),responseDto.userId());
+
+        verify(userRepository, times(1)).findById(uploadUserId);
+        verify(profilePhotoRepository,times(1)).save(any());
+
+        //생성된 null 파일을 지우기 위해 경로를 저장
+        //after
+        deleteFilePath = responseDto.profilePhotoPath();
+    }
+
+    @Test
+    @DisplayName("given_when_then 방식으로 프로필 사진 수정 서비스 성공 테스트")
+    void updatePhotoToFileSystemTest() throws Exception {
+        //given
+        /*mock객체로 upload할 파일 생성*/
+        MultipartFile updateFile = new MockMultipartFile(
+                "profile",
+                "profile",
+                "profile/jpeg",
+                new byte[]{});
+
+        String fileName = FileNameGenerator.generatorName(updateFile.getOriginalFilename());
+        String filePath = FOLDER_PATH + fileName;
+
+        /*업데이트 할 프로필 사진*/
+        ProfilePhoto updateProfilePhoto = ProfilePhoto.builder()
+                .Id(1L)
+                .user(givenUser)
+                .profilePhotoName(updateFile.getOriginalFilename())
+                .profilePhotoPath(filePath)
+                .build();
+        /* 기존의 프로필 사진 */
+        ProfilePhoto oldProfilePhoto = ProfilePhoto.builder()
+                .Id(1L)
+                .user(givenUser)
+                .profilePhotoName("old.jpg")
+                .profilePhotoPath("/olg.jpg")
+                .build();
+
+        Mockito.when(userRepository.findById(1L))
+                .thenReturn(Optional.of(givenUser));
+        Mockito.when(profilePhotoRepository.findProfilePhotoByUser(givenUser)).thenReturn(Optional.of(oldProfilePhoto));
+        Mockito.when(profilePhotoRepository.save(any(ProfilePhoto.class))).thenReturn(updateProfilePhoto);
+
+        //when
+        ProfilePhotoResponseDto responseDto = profilePhotoService.updatePhotoFromFileSystem(1L, updateFile);
+
+        //then
+        Assertions.assertEquals(updateProfilePhoto.getProfilePhotoName(),responseDto.profilePhotoName());
+        Assertions.assertEquals(updateProfilePhoto.getProfilePhotoPath(),responseDto.profilePhotoPath());
+        Assertions.assertEquals(updateProfilePhoto.getUser().getId(),responseDto.userId());
+
+        verify(userRepository,times(1)).findById(1L);
+        verify(profilePhotoRepository,times(1)).findProfilePhotoByUser(givenUser);
+        verify(profilePhotoRepository,times(1)).save(any());
+
+        //생성된 null 파일을 지우기 위해 경로를 저장
+        //after
+        deleteFilePath = responseDto.profilePhotoPath();
+    }
+
+    /* 구현 실패 */
+//    @Test
+//    @DisplayName("given_when_then 방식으로 프로필 사진 삭제 서비스 성공 테스트")
+//    void deletePhotoFromFileSystem() throws Exception {
+//        //given
+//        MultipartFile deleteFile = new MockMultipartFile(
+//                "profile",
+//                "profile",
+//                "profile/jpeg",
+//                resource.getInputStream().readAllBytes());
+//
+//        String fileName = FileNameGenerator.generatorName(deleteFile.getOriginalFilename());
+//        //FOLDER_PATH 가 Null이다.
+//        String filePath = FOLDER_PATH + fileName;
+//        deleteFile.transferTo(new File(filePath));
+//
+//        /*삭제 할 프로필 사진*/
+//        ProfilePhoto deleteProfilePhoto = ProfilePhoto.builder()
+//                .Id(1L)
+//                .user(givenUser)
+//                .profilePhotoName(deleteFile.getOriginalFilename())
+//                .profilePhotoPath(filePath)
+//                .build();
+//
+//        Mockito.when(userRepository.findById(1L))
+//                .thenReturn(Optional.of(givenUser));
+//        Mockito.when(profilePhotoRepository.findProfilePhotoByUser(givenUser)).thenReturn(Optional.of(deleteProfilePhoto));
+//
+//        //when
+//        profilePhotoService.deletePhotoFromFileSystem(1L);
+//
+//        //then
+//
+//        verify(userRepository,times(1)).findById(1L);
+//        verify(profilePhotoRepository,times(1)).findProfilePhotoByUser(givenUser);
+//        verify(profilePhotoRepository,times(1)).deleteById(1L);
+//    }
+}

--- a/src/test/java/me/snaptime/user/service/ProfilePhotoServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/ProfilePhotoServiceTest.java
@@ -9,6 +9,8 @@ import me.snaptime.user.data.repository.UserRepository;
 import me.snaptime.user.util.ProfilePhotoNameGenerator;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,9 +29,13 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class ProfilePhotoServiceTest {
 
-    private UserRepository userRepository = Mockito.mock(UserRepository.class);
-    private ProfilePhotoRepository profilePhotoRepository = Mockito.mock(ProfilePhotoRepository.class);
+    @InjectMocks
     private ProfilePhotoService profilePhotoService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ProfilePhotoRepository profilePhotoRepository;
 
     private String deleteFilePath;
     private User givenUser;
@@ -38,7 +44,6 @@ public class ProfilePhotoServiceTest {
 
     @BeforeEach
     public void setUpTest(){
-        profilePhotoService = new ProfilePhotoService(userRepository,profilePhotoRepository);
         givenUser =  User.builder()
                 .Id(1L)
                 .name("홍길순")

--- a/src/test/java/me/snaptime/user/service/UserServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/UserServiceTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.Optional;
@@ -18,23 +21,21 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
-
-//    @InjectMocks
-//    private UserService userService;
-//
-//    @Mock
-//    private UserRepository userRepository;
-
-    private final UserRepository userRepository = Mockito.mock(UserRepository.class);
+    @InjectMocks
     private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
 
     private User givenUser;
 
     @BeforeEach
     public void setUpTestSet() {
-        userService = new UserService(userRepository);
         givenUser = User.builder()
                 .Id(1L)
                 .name("홍길순")

--- a/src/test/java/me/snaptime/user/service/UserServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/UserServiceTest.java
@@ -30,16 +30,12 @@ class UserServiceTest {
     private final UserRepository userRepository = Mockito.mock(UserRepository.class);
     private UserService userService;
 
+    private User givenUser;
+
     @BeforeEach
     public void setUpTestSet() {
         userService = new UserService(userRepository);
-    }
-
-    @Test
-    @DisplayName("given_when_then 방식으로 getUser 서비스 성공 테스트")
-    void getUser() {
-        //given
-        User givenUser = User.builder()
+        givenUser = User.builder()
                 .Id(1L)
                 .name("홍길순")
                 .loginId("kang4746")
@@ -47,7 +43,12 @@ class UserServiceTest {
                 .email("strong@gmail.com")
                 .birthDay("1999-10-29")
                 .build();
+    }
 
+    @Test
+    @DisplayName("given_when_then 방식으로 getUser 서비스 성공 테스트")
+    public void getUser() {
+        //given
         Mockito.when(userRepository.findById(1L))
                 .thenReturn(Optional.of(givenUser));
         //when
@@ -66,9 +67,15 @@ class UserServiceTest {
 
     @Test
     @DisplayName("given_when_then 방식으로 signUp 서비스 성공 테스트")
-    void signUp() {
+    public void signUp() {
         //given
-        UserRequestDto givenRequest = new UserRequestDto("홍길순","kang4746","test1234","strong@gmail.com","1999-10-29");
+        UserRequestDto givenRequest = UserRequestDto.builder()
+                .name("홍길순")
+                .loginId("kang4746")
+                .password("test1234")
+                .email("strong@gmail.com")
+                .birthDay("1999-10-29")
+                .build();
 
 
         //userRepository.save(any(User.class)) 메서드가 호출되면
@@ -90,38 +97,22 @@ class UserServiceTest {
 
     @Test
     @DisplayName("given_when_then 방식으로 deleteUser 서비스 성공 테스트")
-    void deleteUser() {
+    public void deleteUser() {
         //given
-        User givenUser = User.builder()
-                .Id(1L)
-                .name("홍길순")
-                .loginId("kang4746")
-                .password("test1234")
-                .email("strong@gmail.com")
-                .birthDay("1999-10-29")
-                .build();
-
         Mockito.when(userRepository.findById(1L))
                 .thenReturn(Optional.of(givenUser));
         //when
         userService.deleteUser(1L);
 
         //then
+        verify(userRepository,times(1)).findById(1L);
         verify(userRepository,times(1)).deleteById(1L);
     }
 
     @Test
     @DisplayName("given_when_then 방식으로 updateUser 서비스 성공 테스트")
-    void updateUser() {
+    public void updateUser() {
         //given
-        User givenUser = User.builder()
-                .Id(1L)
-                .name("홍길순")
-                .loginId("kang4746")
-                .password("test1234")
-                .email("strong@gmail.com")
-                .birthDay("1999-10-29")
-                .build();
 
         UserUpdateDto userUpdateDto = new UserUpdateDto("string","jun4746","strong@naver.com","string");
         Mockito.when(userRepository.findById(1L))


### PR DESCRIPTION
## 📋 이슈 번호
close #19 
## 🛠 구현 사항
1. 프로필 사진의 컨트롤러 ,서비스 클래스 추가 로 crud 기능을 구현
2. 유저, 프로필 사진 컨트롤러 파라미터에 설명 추가 
3. 프로필 사진 request, response dto 추가 
4. 프로필 사진  Test 코드 추가// 미완성 
5. 프로필 사진 전용 ProfilePhotoNameGenserator 추가
## 📚 기타
User관련 실패 Test코드는 추가 할 예정입니다.
ProfilePhoto 관련 테스트 코드 작성에는 아직 어려움이 있어서 공부 후 빠른 시일 내에 작성 해 보도록 하겠습니다.. 
user폴더의 프로필 사진이 snap폴더의 FileNameGenerator를 사용하게 하였는데 , user 폴더에 프로필 사진 전용 ProfilePhotoNameGenserator  을 추가하였습니다.
