### PR TITLE
[Fix] 프로필 조회,예외처리,테이블 에러 수정 

### DIFF
--- a/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
+++ b/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
@@ -15,6 +15,8 @@ public enum ExceptionCode {
     ACCESS_FAIL_FRIENDSHIP(HttpStatus.FORBIDDEN,"해당 친구에 대한 권한이 없습니다."),
 
     // ProfilePhotoException
+    PROFILE_PHOTO_EXIST(HttpStatus.BAD_REQUEST,"이미 프로필 사진이 존재합니다."),
+    PROFILE_PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 프로필 사진입니다."),
     FILE_NOT_EXIST(HttpStatus.NOT_FOUND,"해당하는 경로에 파일이 존재하지 않습니다.");
 
 

--- a/src/main/java/me/snaptime/user/data/controller/ProfilePhotoController.java
+++ b/src/main/java/me/snaptime/user/data/controller/ProfilePhotoController.java
@@ -41,7 +41,7 @@ public class ProfilePhotoController {
 
     @Operation(summary = "프로필 사진 조회",description = "유저의 프로필 사진을 조회 합니다.")
     @Parameter(name = "profilePhotoId",description = "조회 할 프로필 사진의 id")
-    @GetMapping()
+    @GetMapping("/{profilePhotoId}")
     public ResponseEntity<?> downloadProfileToFileSystem(@PathVariable("profilePhotoId") Long profilePhotoId) {
         log.info("[downloadProfile] 유저의 프로필 사진을 조회합니다.");
 

--- a/src/main/java/me/snaptime/user/data/controller/UserController.java
+++ b/src/main/java/me/snaptime/user/data/controller/UserController.java
@@ -67,7 +67,7 @@ public class UserController {
     @Operation(summary = "회원가입", description = "회원 가입 할 유저의 정보를 입력합니다.")
     @PostMapping("/sign-up")
     public ResponseEntity<CommonResponseDto<UserResponseDto>> signUp(@RequestBody UserRequestDto userRequestDto){
-        String role = "USER";
+        //String role = "USER";
         log.info("[signUp] 회원가입을 수행합니다. loginId : {}, password : ****, name : {}, email : {}, birthDay : {}",userRequestDto.loginId(),userRequestDto.name(),userRequestDto.email(),userRequestDto.birthDay());
 
         UserResponseDto userResponseDto = userService.signUp(userRequestDto);

--- a/src/main/java/me/snaptime/user/data/domain/User.java
+++ b/src/main/java/me/snaptime/user/data/domain/User.java
@@ -11,7 +11,7 @@ import me.snaptime.common.domain.BaseTimeEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user")
+@Table(name = "users")
 public class User extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## 📋 이슈 번호
close #23 
## 🛠 구현 사항
1. 프로필 사진 조회 요청에 path를 제대로 추가하였습니다
2.  서비스 메서드의 예외 처리를 모두 CustomException 으로 수정하였습니다..
3. 유저 테이블의 이름 user을 예약어가 아닌 users로 수정하였습니다.
4. 트랜잭션 사용시  profileupdate, profiledelete 에서 예외 처리가 안되는 문제를 임시로 처리하였습니다.

## 📚 기타
@Transaction 어노테이션 사용시 profilephoto가 존재하지 않아도 수정이 되고, 삭제 이후에 존재하지 않는 profilephoto 객체와, 파일을 또 삭제해도 성공 메시지가 발생합니다. 
찾아보고 올바른 방향으로 수정 하겠습니다!
