### PR TITLE
[Feat] 댓글,대댓글 수정,삭제로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // Swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
     // Querydsl

--- a/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
+++ b/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
@@ -17,6 +17,7 @@ public enum ExceptionCode {
 
     // Reply Exception
     REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST,"존재하지 않는 댓글입니다."),
+    ACCESS_FAIL_REPLY(HttpStatus.FORBIDDEN,"댓글에 대한 권한이 없습니다."),
 
     // SignIn Exception
     PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST,"잘못된 비밀번호를 입력하셨습니다."),

--- a/src/main/java/me/snaptime/social/controller/ReplyController.java
+++ b/src/main/java/me/snaptime/social/controller/ReplyController.java
@@ -36,7 +36,7 @@ public class ReplyController {
             @Parameter(name = "snapId", description = "댓글등록할 snap의 Id(Long타입으로 입력)", required = true, example = "1"),
     })
     public ResponseEntity<CommonResponseDto> addParentReply(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @AuthenticationPrincipal final UserDetails userDetails,
             @RequestParam @NotBlank(message = "댓글내용을 입력해주세요.") String content,
             @PathVariable final Long snapId){
 
@@ -48,7 +48,7 @@ public class ReplyController {
     @PostMapping("/child-replys")
     @Operation(summary = "대댓글 등록요창", description = "대댓글을 등록할 부모댓글의 Id와 태그할 유저의 loginId,댓글내용을 입력해주세요<br>태그할 유저가 없다면 tagLoginId는 보내지 않아도 됩니다.")
     public ResponseEntity<CommonResponseDto> addChildReply(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @AuthenticationPrincipal final UserDetails userDetails,
             @RequestBody @Valid AddChildReplyReqDto addChildReplyReqDto){
 
         replyService.addChildReply(userDetails.getUsername(), addChildReplyReqDto);
@@ -63,7 +63,7 @@ public class ReplyController {
             @Parameter(name = "snapId", description = "조회할 snapId", required = true, example = "1"),
     })
     public ResponseEntity<CommonResponseDto> readParentReply(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @AuthenticationPrincipal final UserDetails userDetails,
             @PathVariable final Long pageNum,
             @PathVariable final Long snapId){
 
@@ -79,12 +79,68 @@ public class ReplyController {
             @Parameter(name = "parentReplyId", description = "대댓글을 조회할 부모댓글의Id", required = true, example = "1"),
     })
     public ResponseEntity<CommonResponseDto> readChildReply(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @AuthenticationPrincipal final UserDetails userDetails,
             @PathVariable final Long pageNum,
             @PathVariable final Long parentReplyId){
 
         List<FindChildReplyResDto> result = replyService.readChildReply(userDetails.getUsername(),parentReplyId,pageNum);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CommonResponseDto("대댓글조회 성공했습니다.",result));
+    }
+
+    @PatchMapping("/replys/parent/{parentReplyId}")
+    @Operation(summary = "댓글 수정요청", description = "댓글 ID와 수정할 댓글내용을 입력해주세요")
+    @Parameters({
+            @Parameter(name = "parentReplyId", description = "댓글ID", required = true, example = "1"),
+            @Parameter(name = "newContent", description = "수정할 댓글내용", required = true, example = "수정된 댓글"),
+    })
+    public ResponseEntity<CommonResponseDto> updateParentReply(
+            @AuthenticationPrincipal final UserDetails userDetails,
+            @PathVariable final Long parentReplyId,
+            @RequestParam final String newContent){
+
+        replyService.updateParentReply(userDetails.getUsername(),parentReplyId,newContent);
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto("댓글 수정을 완료했습니다",null));
+    }
+
+    @PatchMapping("/replys/child/{childReplyId}")
+    @Operation(summary = "대댓글 수정요청", description = "대댓글 ID와 수정할 댓글내용을 입력해주세요")
+    @Parameters({
+            @Parameter(name = "childReplyId", description = "eo댓글ID", required = true, example = "1"),
+            @Parameter(name = "newContent", description = "수정할 대댓글내용", required = true, example = "수정된 대댓글"),
+    })
+    public ResponseEntity<CommonResponseDto> updateChildReply(
+            @AuthenticationPrincipal final UserDetails userDetails,
+            @PathVariable final Long childReplyId,
+            @RequestParam final String newContent){
+
+        replyService.updateChildReply(userDetails.getUsername(),childReplyId,newContent);
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto("대댓글 수정을 완료했습니다",null));
+    }
+
+    @DeleteMapping("/replys/parent/{parentReplyId}")
+    @Operation(summary = "댓글 삭제요청", description = "삭제할 댓글 ID를 입력해주세요")
+    @Parameters({
+            @Parameter(name = "parentReplyId", description = "댓글ID", required = true, example = "1")
+    })
+    public ResponseEntity<CommonResponseDto> deleteParentReply(
+            @AuthenticationPrincipal final UserDetails userDetails,
+            @PathVariable final Long parentReplyId){
+
+        replyService.deleteParentReply(userDetails.getUsername(),parentReplyId);
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto("댓글 삭제를 완료했습니다",null));
+    }
+
+    @DeleteMapping("/replys/child/{childReplyId}")
+    @Operation(summary = "대댓글 삭제요청", description = "삭제할 대댓글 ID를 입력해주세요")
+    @Parameters({
+            @Parameter(name = "childReplyId", description = "대댓글ID", required = true, example = "1")
+    })
+    public ResponseEntity<CommonResponseDto> deleteChildReply(
+            @AuthenticationPrincipal final UserDetails userDetails,
+            @PathVariable final Long childReplyId){
+
+        replyService.deleteChildReply(userDetails.getUsername(),childReplyId);
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto("대댓글 삭제를 완료했습니다",null));
     }
 }

--- a/src/main/java/me/snaptime/social/data/dto/res/FindChildReplyResDto.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FindChildReplyResDto.java
@@ -9,9 +9,9 @@ import static me.snaptime.social.data.domain.QChildReply.childReply;
 @Builder
 public record FindChildReplyResDto(
 
-        String loginId,
-        String userName,
-        String profilePhotoURL,
+        String writerLoginId,
+        String writerUserName,
+        String writerProfilePhotoURL,
         String content,
         String tagUserLoginId,
         String tagUserName,
@@ -24,9 +24,9 @@ public record FindChildReplyResDto(
         QUser writerUser = new QUser("writerUser");
 
         return FindChildReplyResDto.builder()
-                .loginId(result.get(writerUser.loginId))
-                .profilePhotoURL(profilePhotoURL)
-                .userName(result.get(writerUser.name))
+                .writerLoginId(result.get(writerUser.loginId))
+                .writerProfilePhotoURL(profilePhotoURL)
+                .writerUserName(result.get(writerUser.name))
                 .content(result.get(childReply.content))
                 .tagUserLoginId(result.get(tagUser.loginId))
                 .tagUserName(result.get(tagUser.name))

--- a/src/main/java/me/snaptime/social/data/dto/res/FindParentReplyResDto.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FindParentReplyResDto.java
@@ -9,17 +9,17 @@ import static me.snaptime.user.data.domain.QUser.user;
 @Builder
 public record FindParentReplyResDto(
 
-        String loginId,
-        String profilePhotoURL,
-        String userName,
+        String writerLoginId,
+        String writerProfilePhotoURL,
+        String writerUserName,
         String content,
         Long replyId
 ) {
     public static FindParentReplyResDto toDto(Tuple result, String profilePhotoURL){
         return FindParentReplyResDto.builder()
-                .loginId(result.get(user.loginId))
-                .profilePhotoURL(profilePhotoURL)
-                .userName(result.get(user.name))
+                .writerLoginId(result.get(user.loginId))
+                .writerProfilePhotoURL(profilePhotoURL)
+                .writerUserName(result.get(user.name))
                 .content(result.get(parentReply.content))
                 .replyId(result.get(parentReply.id))
                 .build();

--- a/src/main/java/me/snaptime/social/service/FriendShipService.java
+++ b/src/main/java/me/snaptime/social/service/FriendShipService.java
@@ -16,7 +16,6 @@ import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## 📋 이슈 번호
close #50 

## 🛠 구현 사항

- 댓글, 대댓글 수정,삭제 로직을 구현했습니다.

- snap이 삭제될 경우 snap에 등록된 댓글이 정상적으로 삭제되는지 테스트는 snap삭제로직이 구현되지 않아 테스트해보지 못했습니다.
- user 탈퇴 시 해당 유저가 등록한snap에 영속성전이가 되지 않아 오류가 발생하여 user탈퇴시 해당 유저가 틍록한 댓글이 정상적으로 삭제되는지에 대한 테스트또한 테스트해보지 못했습니다.

## 📚 기타
