### PR TITLE
[Fix] 유저 프로필 album, snap 조회 수정 

### DIFF
--- a/src/main/java/me/snaptime/common/config/SecurityConfig.java
+++ b/src/main/java/me/snaptime/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         requests
                                 .requestMatchers("/swagger-resources/**", "/swagger-ui/index.html", "/webjars/**", "/swagger/**", "/users/exception", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                                 .requestMatchers("/users/sign-in", "/users/sign-up").permitAll()
-                                .requestMatchers(HttpMethod.GET,"/users/profile","/users/", "/profile_photos/**","/snap/**","/friends/**").permitAll()
+                                .requestMatchers(HttpMethod.GET,"/users/profile", "/profile_photos/**","/snap/**","/friends/**").permitAll()
                                 .requestMatchers("**exception**").permitAll()
                                 .anyRequest().hasRole("USER")
                 )

--- a/src/main/java/me/snaptime/common/config/SecurityConfig.java
+++ b/src/main/java/me/snaptime/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         requests
                                 .requestMatchers("/swagger-resources/**", "/swagger-ui/index.html", "/webjars/**", "/swagger/**", "/users/exception", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                                 .requestMatchers("/users/sign-in", "/users/sign-up").permitAll()
-                                .requestMatchers(HttpMethod.GET,"/users","/profile_photos/**","/snap/**","/friends/**").permitAll()
+                                .requestMatchers(HttpMethod.GET,"/users/profile","/users/", "/profile_photos/**","/snap/**","/friends/**").permitAll()
                                 .requestMatchers("**exception**").permitAll()
                                 .anyRequest().hasRole("USER")
                 )

--- a/src/main/java/me/snaptime/user/controller/UserController.java
+++ b/src/main/java/me/snaptime/user/controller/UserController.java
@@ -100,8 +100,10 @@ public class UserController {
     @Operation(summary = "유저 앨범, 스냅 조회", description = "유저의 앨범들과, 각 앨범의 스냅들을 조회합니다.")
     @Parameter(name = "login_id", description = "앨범과 사진들을 가져오기 위한 loginId", required = true)
     @GetMapping("/album_snap")
-    public ResponseEntity<CommonResponseDto<List<AlbumSnapResDto>>> getAlbumSnap(@RequestParam("login_id") String loginId){
-        List<AlbumSnapResDto> albumSnapResDtoList = userService.getAlbumSnap(loginId);
+    public ResponseEntity<CommonResponseDto<List<AlbumSnapResDto>>> getAlbumSnap(@AuthenticationPrincipal UserDetails principal,
+                                                                                 @RequestParam("login_id") String targetLoginId){
+        String yourLoginId = principal.getUsername();
+        List<AlbumSnapResDto> albumSnapResDtoList = userService.getAlbumSnap(yourLoginId, targetLoginId);
         return ResponseEntity.status(HttpStatus.OK).body(
                 new CommonResponseDto<>(
                         "유저 앨범과 스냅 조회를 성공적으로 완료하였습니다.",

--- a/src/main/java/me/snaptime/user/data/repository/UserCustomRepository.java
+++ b/src/main/java/me/snaptime/user/data/repository/UserCustomRepository.java
@@ -6,6 +6,6 @@ import me.snaptime.user.data.dto.response.userprofile.AlbumSnapResDto;
 import java.util.List;
 
 public interface UserCustomRepository {
-    List<AlbumSnapResDto> fidAlbumSnap(User reqUser);
+    List<AlbumSnapResDto> findAlbumSnap(User targetUser, Boolean checkPermission);
 
 }

--- a/src/main/java/me/snaptime/user/data/repository/impl/UserCustomRepositoryImpl.java
+++ b/src/main/java/me/snaptime/user/data/repository/impl/UserCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package me.snaptime.user.data.repository.impl;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -10,8 +11,7 @@ import me.snaptime.user.data.dto.response.userprofile.ProfileCntResDto;
 import me.snaptime.user.data.repository.UserCustomRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static me.snaptime.snap.data.domain.QAlbum.album;
 import static me.snaptime.snap.data.domain.QSnap.snap;
@@ -25,28 +25,38 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
     private final UrlComponent urlComponent;
 
     //유저 앨범들과 앨범에 해당하는 스냅들 가져오는 메서드.
+    //앨범에 snap이 존재하지 않아도 return 할 list에 album만 추가하고 나머지 null처리
+    //snap에 isPrivate이 존재한다, 내가 조회 -> 전부 리턴 | 남이 조회 -> isPrivate= True 인 snap 제외
     @Override
-    public List<AlbumSnapResDto> fidAlbumSnap(User reqUser) {
-        List<Long> albumIdList = jpaQueryFactory
-                .select(album.id).distinct()
+    public List<AlbumSnapResDto> findAlbumSnap(User targetUser, Boolean checkPermission) {
+        List<Tuple> albumList = jpaQueryFactory
+                .select(album.id, album.name).distinct()
                 .from(user)
-                .join(snap).on(user.id.eq(snap.user.id))
-                .join(album).on(snap.album.id.eq(album.id))
-                .where(user.id.eq(reqUser.getId()))
+                .join(album).on(user.id.eq(album.user.id))
+                .where(user.id.eq(targetUser.getId()))
                 .fetch();
+
+        Map<Long,String> albumMap = new HashMap<>();
+
+        albumList.forEach(tuple ->{
+            Long albumId = tuple.get(album.id);
+            String albumName = tuple.get(album.name);
+            albumMap.put(albumId,albumName);
+        });
 
         List<AlbumSnapResDto> albumSnapResDtoList = new ArrayList<>();
 
-        for (Long albumId : albumIdList) {
+
+        //snap이 없어도 album은 존재할 수 있기 때문에 album 수 만큼 반복한다.
+        for (Long albumId : albumMap.keySet()) {
             List<Tuple> albumSnapTwo = jpaQueryFactory
                     .select(album.name, snap.fileName, snap.isPrivate)
-                    .from(snap)
-                    .join(album).on(snap.album.id.eq(album.id))
-                    .where(album.id.eq(albumId))
+                    .from(album)
+                    .leftJoin(snap).on(album.id.eq(snap.album.id))
+                    .where(whereBuilder(albumId, checkPermission))
                     .orderBy(snap.createdDate.desc()) // 최근 생성일 기준으로 내림차순 정렬
                     .limit(2) // 최근 생성된 사진 2개만 선택
                     .fetch();
-
 
             //stream 사용하는 걸로 수정
             List<String> snapUrlList = albumSnapTwo.stream()
@@ -57,7 +67,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
                     })
                     .toList();
 
-            String albumName = albumSnapTwo.get(0).get(album.name);
+            String albumName = albumMap.get(albumId);
 
             albumSnapResDtoList.add(AlbumSnapResDto.builder()
                     .albumId(albumId)
@@ -67,6 +77,23 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
         }
 
         return albumSnapResDtoList;
+    }
+
+    // 자신이 자신의 profile을 조회할 때, 다른 사람이 자신의 profile을 조회할 때를 구별하기 위함.
+    private BooleanBuilder whereBuilder(Long albumId, Boolean checkPermission){
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(checkPermission){
+            builder.and(album.id.eq(albumId));
+            builder.and(snap.fileName.isNotNull());
+        }
+        else{
+            builder.and(album.id.eq(albumId));
+            builder.and(snap.isPrivate.isFalse());
+            builder.and(snap.fileName.isNotNull());
+        }
+
+        return builder;
     }
 }
 

--- a/src/main/java/me/snaptime/user/service/UserService.java
+++ b/src/main/java/me/snaptime/user/service/UserService.java
@@ -26,6 +26,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -136,10 +137,16 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public List<AlbumSnapResDto> getAlbumSnap(String loginId){
-        User reqUser = userRepository.findByLoginId(loginId).orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_EXIST));
+    public List<AlbumSnapResDto> getAlbumSnap(String yourLoginId, String targetLoginId){
+        User targetUser = userRepository.findByLoginId(targetLoginId).orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
-        List<AlbumSnapResDto> albumSnapResDtoList = userRepository.fidAlbumSnap(reqUser);
+        List<AlbumSnapResDto> albumSnapResDtoList = new ArrayList<>();
+        if(yourLoginId.equals(targetLoginId)){
+             albumSnapResDtoList = userRepository.findAlbumSnap(targetUser,true);
+        }
+        else{
+             albumSnapResDtoList = userRepository.findAlbumSnap(targetUser,false);
+        }
 
         return albumSnapResDtoList;
     }


### PR DESCRIPTION
## 📋 이슈 번호
close #55 
## 🛠 구현 사항
토큰을 통해 메서드 호출하는 유저를 파악한 후, findAlbumSnap 메서드에서, album을 전부 가져오고, 앨범에 해당하는 snap의 유무와,  snap의 private 상태를 체크하여 리턴할 list를 채우는 방식으로 수정하였습니다.
## 📚 기타
