### PR TITLE
[Refactor] /album/{album_id} API 통합 

### DIFF
--- a/src/main/java/me/snaptime/snap/controller/AlbumController.java
+++ b/src/main/java/me/snaptime/snap/controller/AlbumController.java
@@ -85,7 +85,7 @@ public class AlbumController {
     }
 
     @Operation(summary = "Album의 이름을 변경합니다.")
-    @PatchMapping("/")
+    @PatchMapping
     public ResponseEntity<CommonResponseDto<Void>> modifyAlbumName(
             final @RequestParam("album_name") String name,
             final @RequestParam("album_id") Long id

--- a/src/main/java/me/snaptime/snap/service/impl/AlbumServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/AlbumServiceImpl.java
@@ -55,7 +55,29 @@ public class AlbumServiceImpl implements AlbumService {
     @Transactional(readOnly = true)
     public FindAlbumResDto findAlbum(String uId, Long album_id) {
         Album foundAlbum = albumRepository.findById(album_id).orElseThrow(() -> new CustomException(ExceptionCode.ALBUM_NOT_EXIST));
-        haveAuthority(uId, foundAlbum);
+        try {
+            haveAuthority(uId, foundAlbum);
+        } catch (CustomException e) {
+            /*
+            * 유저가 없거나, 권한이 없으면 공개인 것만 유저에게 반환한다.
+            * */
+            return FindAlbumResDto.builder()
+                    .id(foundAlbum.getId())
+                    .name(foundAlbum.getName())
+                    .snap(foundAlbum.getSnap().stream()
+                            .sorted(Comparator.comparing(Snap::getId).reversed())
+                            .filter( snap -> !snap.isPrivate())
+                            .map(snap ->
+                                    FindSnapResDto.entityToResDto(
+                                            snap,
+                                            urlComponent.makePhotoURL(snap.getFileName(), false),
+                                            urlComponent.makeProfileURL(snap.getUser().getProfilePhoto().getId())
+                                    )
+                            )
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+
         return FindAlbumResDto.builder()
                 .id(foundAlbum.getId())
                 .name(foundAlbum.getName())
@@ -70,6 +92,7 @@ public class AlbumServiceImpl implements AlbumService {
                         )
                         .collect(Collectors.toList()))
                 .build();
+
     }
 
     @Override


### PR DESCRIPTION
## 📋 이슈 번호
close #69 
## 🛠 구현 사항
다른 사람의 프로필에서 앨범을 조회했을 때 앨범에 있는 snap들을 조회하는 API와 자기 자신의 앨범의 snap을 조회하는 요청을 하나로 통합합니다.
## 📚 기타
