### PR TITLE
[Feat/Fix] userTagSnap메서드 추가 userUpdate 수정 

### DIFF
--- a/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
+++ b/src/main/java/me/snaptime/common/exception/customs/ExceptionCode.java
@@ -36,7 +36,6 @@ public enum ExceptionCode {
     USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "사용자가 존재하지 않습니다."),
     PASSWORD_DUPLICATE(HttpStatus.BAD_REQUEST,"같은 비밀번호로 수정 할 수 없습니다."),
     LOGIN_ID_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 존재하는 loginId 입니다."),
-    SAME_LOGIN_ID(HttpStatus.BAD_REQUEST, "이전과 동일한 loginId 입니다."),
 
     // Snap Exception
     SNAP_NOT_EXIST(HttpStatus.BAD_REQUEST, "스냅이 존재하지 않습니다."),

--- a/src/main/java/me/snaptime/user/controller/UserController.java
+++ b/src/main/java/me/snaptime/user/controller/UserController.java
@@ -15,6 +15,7 @@ import me.snaptime.user.data.dto.response.SignInResDto;
 import me.snaptime.user.data.dto.response.UserResDto;
 import me.snaptime.user.data.dto.response.userprofile.AlbumSnapResDto;
 import me.snaptime.user.data.dto.response.userprofile.ProfileCntResDto;
+import me.snaptime.user.data.dto.response.userprofile.ProfileTagSnapResDto;
 import me.snaptime.user.data.dto.response.userprofile.UserProfileResDto;
 import me.snaptime.user.service.UserService;
 import org.springframework.http.HttpStatus;
@@ -148,6 +149,19 @@ public class UserController {
                 new CommonResponseDto<>(
                         "유저 팔로워, 팔로잉 수 조회를 성공적으로 완료하였습니다.",
                         profileCntResDto
+                ));
+    }
+
+    @Operation(summary = "자신이 태그된 snap 들 조회", description = "자신의 Token 을 통하여 자신이 태그된 snap 들을 조회합니다" +
+            "<br> snap id 기준 내림차순으로 조회합니다.(최근 snap 이 제일 먼저 조회)")
+    @GetMapping("/profile/tag")
+    public ResponseEntity<CommonResponseDto<List<ProfileTagSnapResDto>>> getTagSnap(@AuthenticationPrincipal UserDetails principal){
+
+        List<ProfileTagSnapResDto> profileTagSnapResDto = userService.getTagSnap(principal.getUsername());
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CommonResponseDto<>(
+                        "유저가 태그된 Snap 들을 성공적으로 조회하였습니다.",
+                        profileTagSnapResDto
                 ));
     }
 

--- a/src/main/java/me/snaptime/user/data/dto/response/userprofile/ProfileTagSnapResDto.java
+++ b/src/main/java/me/snaptime/user/data/dto/response/userprofile/ProfileTagSnapResDto.java
@@ -1,0 +1,12 @@
+package me.snaptime.user.data.dto.response.userprofile;
+
+import lombok.Builder;
+
+@Builder
+public record ProfileTagSnapResDto(
+
+        Long taggedSnapId,
+        String snapOwnLoginId,
+        String taggedSnapUrl
+
+){}

--- a/src/main/java/me/snaptime/user/data/repository/UserCustomRepository.java
+++ b/src/main/java/me/snaptime/user/data/repository/UserCustomRepository.java
@@ -2,10 +2,11 @@ package me.snaptime.user.data.repository;
 
 import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.dto.response.userprofile.AlbumSnapResDto;
+import me.snaptime.user.data.dto.response.userprofile.ProfileTagSnapResDto;
 
 import java.util.List;
 
 public interface UserCustomRepository {
     List<AlbumSnapResDto> findAlbumSnap(User targetUser, Boolean checkPermission);
-
+    List<ProfileTagSnapResDto> findTagSnap(User reqUser);
 }

--- a/src/main/java/me/snaptime/user/data/repository/UserRepository.java
+++ b/src/main/java/me/snaptime/user/data/repository/UserRepository.java
@@ -9,6 +9,4 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User,Long>,UserCustomRepository{
     Optional<User> findByLoginId(String loginId);
-    Optional<User> findUserByName(String name);
-
 }

--- a/src/main/java/me/snaptime/user/service/UserService.java
+++ b/src/main/java/me/snaptime/user/service/UserService.java
@@ -19,6 +19,7 @@ import me.snaptime.user.data.dto.response.SignInResDto;
 import me.snaptime.user.data.dto.response.UserResDto;
 import me.snaptime.user.data.dto.response.userprofile.AlbumSnapResDto;
 import me.snaptime.user.data.dto.response.userprofile.ProfileCntResDto;
+import me.snaptime.user.data.dto.response.userprofile.ProfileTagSnapResDto;
 import me.snaptime.user.data.dto.response.userprofile.UserProfileResDto;
 import me.snaptime.user.data.repository.ProfilePhotoRepository;
 import me.snaptime.user.data.repository.UserRepository;
@@ -104,11 +105,7 @@ public class UserService {
 
         User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
-        if(user.getLoginId().equals(userUpdateDto.loginId())){
-            throw new CustomException(ExceptionCode.SAME_LOGIN_ID);
-        }
-
-        if(userRepository.findByLoginId(userUpdateDto.loginId()).isPresent()){
+        if(!loginId.equals(userUpdateDto.loginId()) && userRepository.findByLoginId(userUpdateDto.loginId()).isPresent()){
             throw new CustomException(ExceptionCode.LOGIN_ID_ALREADY_EXIST);
         }
 
@@ -153,9 +150,7 @@ public class UserService {
     public List<AlbumSnapResDto> getAlbumSnap(String yourLoginId, String targetLoginId){
         User targetUser = userRepository.findByLoginId(targetLoginId).orElseThrow(()-> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
-        List<AlbumSnapResDto> albumSnapResDtoList = new ArrayList<>();
-        //자신이 자신의 profile을 조회하면 true, 다른 사람의 prfoile을 조회하면, false 를 매개변수로 전달한다
-        albumSnapResDtoList = userRepository.findAlbumSnap(targetUser,yourLoginId.equals(targetLoginId));
+        List<AlbumSnapResDto> albumSnapResDtoList = userRepository.findAlbumSnap(targetUser,yourLoginId.equals(targetLoginId));
         
         return albumSnapResDtoList;
     }
@@ -180,5 +175,13 @@ public class UserService {
                 .followerCnt(friendCntResDto.followerCnt())
                 .followingCnt(friendCntResDto.followingCnt())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProfileTagSnapResDto> getTagSnap(String loginId){
+        User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
+        List<ProfileTagSnapResDto> profileTagSnapList = userRepository.findTagSnap(user);
+
+        return profileTagSnapList;
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
close #77 
## 🛠 구현 사항

유저 프로필의 태그 목록 페이지에서 유저 자신이 태그된 snap들을 조회하는 메서드 userTagSnap 메서드를 추가합니다.

userUpdate 메서드에서, 이전과 동일한 이름으로 수정 할 수 없게 했었는데, 이 상황에선 이름만 바꾸려고 해도 무조건 loginId를 수정해야 하므로 이전과 같은 loginId로 수정할 수 있게 합니다.

## 📚 기타
