### PR TITLE
[Refactor] 댓글 api 리팩토링 & 다른 유저의 친구목록 조회가 가능하도록 수정

### DIFF
--- a/src/main/java/me/snaptime/common/component/impl/CheckNextPageComponentImpl.java
+++ b/src/main/java/me/snaptime/common/component/impl/CheckNextPageComponentImpl.java
@@ -1,0 +1,18 @@
+package me.snaptime.common.component.impl;
+
+import com.querydsl.core.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CheckNextPageComponentImpl {
+
+    public boolean hasNextPage(List<Tuple> resultList, Long pageSize){
+
+        boolean hasNextPage = resultList.size() <= pageSize ? false : true;
+        return hasNextPage;
+    }
+}

--- a/src/main/java/me/snaptime/common/component/impl/NextPageChecker.java
+++ b/src/main/java/me/snaptime/common/component/impl/NextPageChecker.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class CheckNextPageComponentImpl {
+public class NextPageChecker {
 
     public boolean hasNextPage(List<Tuple> resultList, Long pageSize){
 

--- a/src/main/java/me/snaptime/common/component/impl/TimeAgoCalculator.java
+++ b/src/main/java/me/snaptime/common/component/impl/TimeAgoCalculator.java
@@ -1,0 +1,43 @@
+package me.snaptime.common.component.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@RequiredArgsConstructor
+public class TimeAgoCalculator {
+
+    public String findTimeAgo(LocalDateTime calculatedTime){
+
+        // 현재 서울 시간 구하기
+        ZonedDateTime currentTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime nowSeoulLocalDateTime = currentTime.toLocalDateTime();
+
+        // 시간 차이 계산
+        long years = ChronoUnit.YEARS.between(calculatedTime, nowSeoulLocalDateTime);
+        long months = ChronoUnit.MONTHS.between(calculatedTime, nowSeoulLocalDateTime);
+        long days = ChronoUnit.DAYS.between(calculatedTime, nowSeoulLocalDateTime);
+        long hours = ChronoUnit.HOURS.between(calculatedTime, nowSeoulLocalDateTime);
+        long minutes = ChronoUnit.MINUTES.between(calculatedTime, nowSeoulLocalDateTime);
+
+        if (years > 0) {
+            return years + "년 전";
+        } else if (months > 0) {
+            return months + "달 전";
+        } else if (days > 0) {
+            return days + "일 전";
+        } else if (hours > 0) {
+            return hours + "시간 전";
+        } else if (minutes > 0) {
+            return minutes + "분 전";
+        } else {
+            return "방금 전";
+        }
+    }
+
+}

--- a/src/main/java/me/snaptime/snap/controller/SnapPagingController.java
+++ b/src/main/java/me/snaptime/snap/controller/SnapPagingController.java
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "[Social] Snap API")
@@ -27,7 +25,7 @@ public class SnapPagingController {
     @Operation(summary = "Snap 조회", description = "커뮤니티에서 Snap을 10개씩 페이징조회합니다.")
     @Parameter(name = "pageNum", description = "Snap페이지 번호를 보내주세요")
     @GetMapping("/community/snaps/{pageNum}")
-    public ResponseEntity<CommonResponseDto<List<FindSnapPagingResDto>>> findSnapPaging(
+    public ResponseEntity<CommonResponseDto<FindSnapPagingResDto>> findSnapPaging(
             @AuthenticationPrincipal final UserDetails userDetails,
             @PathVariable final Long pageNum) {
 

--- a/src/main/java/me/snaptime/snap/controller/SnapPagingController.java
+++ b/src/main/java/me/snaptime/snap/controller/SnapPagingController.java
@@ -13,13 +13,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/snaps")
 @RequiredArgsConstructor
 @Tag(name = "[Social] Snap API")
 public class SnapPagingController {
@@ -28,7 +26,7 @@ public class SnapPagingController {
 
     @Operation(summary = "Snap 조회", description = "커뮤니티에서 Snap을 10개씩 페이징조회합니다.")
     @Parameter(name = "pageNum", description = "Snap페이지 번호를 보내주세요")
-    @GetMapping("/community/{pageNum}")
+    @GetMapping("/community/snaps/{pageNum}")
     public ResponseEntity<CommonResponseDto<List<FindSnapPagingResDto>>> findSnapPaging(
             @AuthenticationPrincipal final UserDetails userDetails,
             @PathVariable final Long pageNum) {

--- a/src/main/java/me/snaptime/snap/data/dto/res/FindSnapPagingResDto.java
+++ b/src/main/java/me/snaptime/snap/data/dto/res/FindSnapPagingResDto.java
@@ -1,42 +1,19 @@
 package me.snaptime.snap.data.dto.res;
 
-import com.querydsl.core.Tuple;
 import lombok.Builder;
-import me.snaptime.social.data.dto.res.FindTagUserResDto;
 
-import java.time.LocalDateTime;
 import java.util.List;
-
-import static me.snaptime.snap.data.domain.QSnap.snap;
-import static me.snaptime.user.data.domain.QUser.user;
 
 @Builder
 public record FindSnapPagingResDto(
-        Long snapId,
-        String oneLineJournal,
-        String snapPhotoURL,
-        LocalDateTime snapCreatedDate,
-        LocalDateTime snapModifiedDate,
-        String loginId,
-        String profilePhotoURL,
-        String userName,
-        List<FindTagUserResDto> findTagUserList,
-        Long likeCnt
 
+    List<SnapPagingInfo> snapPagingInfoList,
+    boolean hasNextPage
 ) {
-    public static FindSnapPagingResDto toDto(Tuple result, String profilePhotoURL, String snapPhotoURL,
-                                             List<FindTagUserResDto> findTagUserList, Long likeCnt){
+    public static FindSnapPagingResDto toDto(List<SnapPagingInfo> snapPagingInfoList, boolean hasNextPage){
         return FindSnapPagingResDto.builder()
-                .snapId(result.get(snap.id))
-                .oneLineJournal(String.valueOf(result.get(snap.oneLineJournal)))
-                .snapPhotoURL(snapPhotoURL)
-                .snapCreatedDate(result.get(snap.createdDate))
-                .snapModifiedDate(result.get(snap.lastModifiedDate))
-                .loginId(result.get(user.loginId))
-                .profilePhotoURL(profilePhotoURL)
-                .userName(result.get(user.name))
-                .findTagUserList(findTagUserList)
-                .likeCnt(likeCnt)
+                .snapPagingInfoList(snapPagingInfoList)
+                .hasNextPage(hasNextPage)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/snap/data/dto/res/SnapPagingInfo.java
+++ b/src/main/java/me/snaptime/snap/data/dto/res/SnapPagingInfo.java
@@ -1,0 +1,43 @@
+package me.snaptime.snap.data.dto.res;
+
+import com.querydsl.core.Tuple;
+import lombok.Builder;
+import me.snaptime.social.data.dto.res.FindTagUserResDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static me.snaptime.snap.data.domain.QSnap.snap;
+import static me.snaptime.user.data.domain.QUser.user;
+
+@Builder
+public record SnapPagingInfo(
+
+        Long snapId,
+        String oneLineJournal,
+        String snapPhotoURL,
+        LocalDateTime snapCreatedDate,
+        LocalDateTime snapModifiedDate,
+        String loginId,
+        String profilePhotoURL,
+        String userName,
+        List<FindTagUserResDto> findTagUserList,
+        Long likeCnt
+) {
+    public static SnapPagingInfo toDto(Tuple result, String profilePhotoURL, String snapPhotoURL,
+                                             List<FindTagUserResDto> findTagUserList, Long likeCnt){
+        return SnapPagingInfo.builder()
+                .snapId(result.get(snap.id))
+                .oneLineJournal(String.valueOf(result.get(snap.oneLineJournal)))
+                .snapPhotoURL(snapPhotoURL)
+                .snapCreatedDate(result.get(snap.createdDate))
+                .snapModifiedDate(result.get(snap.lastModifiedDate))
+                .loginId(result.get(user.loginId))
+                .profilePhotoURL(profilePhotoURL)
+                .userName(result.get(user.name))
+                .findTagUserList(findTagUserList)
+                .likeCnt(likeCnt)
+                .build();
+    }
+
+}

--- a/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
@@ -3,7 +3,7 @@ package me.snaptime.snap.service.impl;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.common.component.UrlComponent;
-import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
+import me.snaptime.common.component.impl.NextPageChecker;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.snap.data.dto.res.FindSnapPagingResDto;
@@ -32,7 +32,7 @@ public class SnapPagingServiceImpl {
     private final UrlComponent urlComponent;
     private final SnapTagService snapTagService;
     private final SnapLikeService snapLikeService;
-    private final CheckNextPageComponentImpl checkNextPageComponent;
+    private final NextPageChecker nextPageChecker;
 
     // snap 페이징 조회
     public FindSnapPagingResDto findSnapPaging(String loginId, Long pageNum){
@@ -40,7 +40,7 @@ public class SnapPagingServiceImpl {
                 .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
         List<Tuple> result = snapRepository.findSnapPaging(loginId,pageNum,reqUser);
-        boolean hasNextPage = checkNextPageComponent.hasNextPage(result,10L);
+        boolean hasNextPage = nextPageChecker.hasNextPage(result,10L);
         if(hasNextPage)
             result.remove(10);
 

--- a/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
@@ -3,9 +3,11 @@ package me.snaptime.snap.service.impl;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.common.component.UrlComponent;
+import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.snap.data.dto.res.FindSnapPagingResDto;
+import me.snaptime.snap.data.dto.res.SnapPagingInfo;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.social.service.SnapLikeService;
 import me.snaptime.social.service.SnapTagService;
@@ -30,24 +32,30 @@ public class SnapPagingServiceImpl {
     private final UrlComponent urlComponent;
     private final SnapTagService snapTagService;
     private final SnapLikeService snapLikeService;
+    private final CheckNextPageComponentImpl checkNextPageComponent;
 
     // snap 페이징 조회
-    public List<FindSnapPagingResDto> findSnapPaging(String loginId, Long pageNum){
+    public FindSnapPagingResDto findSnapPaging(String loginId, Long pageNum){
         User reqUser = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
         List<Tuple> result = snapRepository.findSnapPaging(loginId,pageNum,reqUser);
+        boolean hasNextPage = checkNextPageComponent.hasNextPage(result,10L);
+        if(hasNextPage)
+            result.remove(10);
 
-        return result.stream().map(entity -> {
+        List<SnapPagingInfo> snapPagingInfoList = result.stream().map(entity ->
+        {
             Long snapId = entity.get(snap.id);
             String profilePhotoURL = urlComponent.makeProfileURL(entity.get(user.profilePhoto.id));
             String snapPhotoURL = urlComponent.makePhotoURL(entity.get(snap.fileName),false);
 
-            return FindSnapPagingResDto
-                    .toDto(entity,profilePhotoURL,snapPhotoURL,
-                            snapTagService.findTagUserList(snapId),
-                            snapLikeService.findSnapLikeCnt(snapId));
-                }).collect(Collectors.toList());
+            return SnapPagingInfo.toDto(entity,profilePhotoURL,snapPhotoURL,
+                    snapTagService.findTagUserList(snapId),
+                    snapLikeService.findSnapLikeCnt(snapId));
+        }).collect(Collectors.toList());
+
+        return FindSnapPagingResDto.toDto(snapPagingInfoList, hasNextPage);
     }
 
 }

--- a/src/main/java/me/snaptime/social/controller/FriendShipController.java
+++ b/src/main/java/me/snaptime/social/controller/FriendShipController.java
@@ -72,17 +72,17 @@ public class FriendShipController {
                     "<br>검색키워드는 필수가 아니며 없으면 입력하지 않아도 됩니다." +
                     "<br>스냅에 친구를 태그하기 위해 태그할 유저 조회를 할 경우 friendSearchType을 팔로잉으로 보내시면 됩니다.")
     @Parameters({
+            @Parameter(name = "loginId" , description = "친구목록을 조회할 유저의 loginId", required = true,example = "tempLoginId"),
             @Parameter(name = "searchKeyword", description = "친구 검색키워드", required = false, example = "홍길동"),
             @Parameter(name = "friendSearchType", description = "검색 타입(팔로워 조회 시 FOLLOWER/팔로잉 조회 시 FOLLOWING)으로 입력해주세요.", required = true, example = "FOLLOWER"),
             @Parameter(name = "pageNum", description = "친구조회 페이지번호", required = true, example = "1")
     })
     public ResponseEntity<CommonResponseDto<List<FindFriendResDto>>> findFriendList(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(name = "loginId") @NotBlank(message = "친구목록을 조회할 유저의 loginId를 입력해주세요.") String loginId,
             @RequestParam(name = "friendSearchType") @NotNull(message = "팔로우,팔로잉중 하나를 입력해주세요.") FriendSearchType friendSearchType,
             @RequestParam(name = "searchKeyword",required = false) String searchKeyword,
             @PathVariable(name = "pageNum") final Long pageNum){
 
-        String loginId = userDetails.getUsername();
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto("친구조회가 완료되었습니다.",
                 friendShipService.findFriendList(loginId,pageNum,friendSearchType,searchKeyword)));
     }

--- a/src/main/java/me/snaptime/social/controller/FriendShipController.java
+++ b/src/main/java/me/snaptime/social/controller/FriendShipController.java
@@ -20,8 +20,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @Validated
 @RequestMapping("/friends")
@@ -77,7 +75,7 @@ public class FriendShipController {
             @Parameter(name = "friendSearchType", description = "검색 타입(팔로워 조회 시 FOLLOWER/팔로잉 조회 시 FOLLOWING)으로 입력해주세요.", required = true, example = "FOLLOWER"),
             @Parameter(name = "pageNum", description = "친구조회 페이지번호", required = true, example = "1")
     })
-    public ResponseEntity<CommonResponseDto<List<FindFriendResDto>>> findFriendList(
+    public ResponseEntity<CommonResponseDto<FindFriendResDto>> findFriendList(
             @RequestParam(name = "loginId") @NotBlank(message = "친구목록을 조회할 유저의 loginId를 입력해주세요.") String loginId,
             @RequestParam(name = "friendSearchType") @NotNull(message = "팔로우,팔로잉중 하나를 입력해주세요.") FriendSearchType friendSearchType,
             @RequestParam(name = "searchKeyword",required = false) String searchKeyword,

--- a/src/main/java/me/snaptime/social/controller/ReplyController.java
+++ b/src/main/java/me/snaptime/social/controller/ReplyController.java
@@ -20,8 +20,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @Validated
 @RequiredArgsConstructor
@@ -58,14 +56,13 @@ public class ReplyController {
             @Parameter(name = "pageNum", description = "페이지번호", required = true, example = "1"),
             @Parameter(name = "snapId", description = "조회할 snapId", required = true, example = "1"),
     })
-    public ResponseEntity<CommonResponseDto<List<FindParentReplyResDto>>> readParentReply(
+    public ResponseEntity<CommonResponseDto<FindParentReplyResDto>> readParentReply(
             @AuthenticationPrincipal final UserDetails userDetails,
             @RequestParam @NotNull(message = "댓글을 조회할 snapId를 입력해주세요.") final Long snapId,
             @PathVariable final Long pageNum){
 
-        List<FindParentReplyResDto> result = replyService.readParentReply(userDetails.getUsername(),snapId,pageNum);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CommonResponseDto("댓글조회 성공했습니다.",result));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResponseDto("댓글조회 성공했습니다.",
+                replyService.readParentReply(userDetails.getUsername(),snapId,pageNum)));
     }
 
     @GetMapping("/child-replies/{pageNum}")
@@ -74,14 +71,13 @@ public class ReplyController {
             @Parameter(name = "pageNum", description = "페이지번호", required = true, example = "1"),
             @Parameter(name = "parentReplyId", description = "대댓글을 조회할 부모댓글의Id", required = true, example = "1"),
     })
-    public ResponseEntity<CommonResponseDto<List<FindChildReplyResDto>>> readChildReply(
+    public ResponseEntity<CommonResponseDto<FindChildReplyResDto>> readChildReply(
             @AuthenticationPrincipal final UserDetails userDetails,
             @RequestParam @NotNull(message = "부모댓글의 Id를 입력해주세요.") final Long parentReplyId,
             @PathVariable final Long pageNum){
 
-        List<FindChildReplyResDto> result = replyService.readChildReply(userDetails.getUsername(),parentReplyId,pageNum);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CommonResponseDto("대댓글조회 성공했습니다.",result));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResponseDto("대댓글조회 성공했습니다.",
+                replyService.readChildReply(userDetails.getUsername(),parentReplyId,pageNum)));
     }
 
     @PatchMapping("/parent-replies/{parentReplyId}")

--- a/src/main/java/me/snaptime/social/controller/SnapLikeController.java
+++ b/src/main/java/me/snaptime/social/controller/SnapLikeController.java
@@ -10,8 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,13 +22,13 @@ public class SnapLikeController {
 
     private final SnapLikeService snapLikeService;
 
-    @PostMapping("/likes/toggle/{snapId}")
+    @PostMapping("/likes/toggle")
     @Operation(summary = "스냅 좋아요 토글", description = "좋아요 토글할 snapId를 보내주세요<br>" +
                                     "특정 유저가 특정스냅에 좋아요를 눌렀다면 좋아요가 취소됩니다.<br>"+
                                     "좋아요를 누르지 않았다면 좋아요가 추가됩니다.")
     public ResponseEntity<CommonResponseDto<Void>> toggleSnapLike(
             @AuthenticationPrincipal final UserDetails userDetails,
-            @PathVariable final Long snapId){
+            @RequestParam final Long snapId){
 
         String message = snapLikeService.toggleSnapLike(userDetails.getUsername(), snapId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/me/snaptime/social/data/dto/res/ChildReplyInfo.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/ChildReplyInfo.java
@@ -1,0 +1,37 @@
+package me.snaptime.social.data.dto.res;
+
+import com.querydsl.core.Tuple;
+import lombok.Builder;
+import me.snaptime.user.data.domain.QUser;
+
+import static me.snaptime.social.data.domain.QChildReply.childReply;
+
+@Builder
+public record ChildReplyInfo(
+
+        String writerLoginId,
+        String writerUserName,
+        String writerProfilePhotoURL,
+        String content,
+        String tagUserLoginId,
+        String tagUserName,
+        Long parentReplyId,
+        Long childReplyId
+) {
+
+    public static ChildReplyInfo toDto(Tuple result, String profilePhotoURL){
+        QUser tagUser = new QUser("tagUser");
+        QUser writerUser = new QUser("writerUser");
+
+        return ChildReplyInfo.builder()
+                .writerLoginId(result.get(writerUser.loginId))
+                .writerProfilePhotoURL(profilePhotoURL)
+                .writerUserName(result.get(writerUser.name))
+                .content(result.get(childReply.content))
+                .tagUserLoginId(result.get(tagUser.loginId))
+                .tagUserName(result.get(tagUser.name))
+                .parentReplyId(result.get(childReply.parentReply.parentReplyId))
+                .childReplyId(result.get(childReply.childReplyId))
+                .build();
+    }
+}

--- a/src/main/java/me/snaptime/social/data/dto/res/ChildReplyInfo.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/ChildReplyInfo.java
@@ -16,10 +16,11 @@ public record ChildReplyInfo(
         String tagUserLoginId,
         String tagUserName,
         Long parentReplyId,
-        Long childReplyId
+        Long childReplyId,
+        String timeAgo
 ) {
 
-    public static ChildReplyInfo toDto(Tuple result, String profilePhotoURL){
+    public static ChildReplyInfo toDto(Tuple result, String profilePhotoURL,String timeAgo){
         QUser tagUser = new QUser("tagUser");
         QUser writerUser = new QUser("writerUser");
 
@@ -32,6 +33,7 @@ public record ChildReplyInfo(
                 .tagUserName(result.get(tagUser.name))
                 .parentReplyId(result.get(childReply.parentReply.parentReplyId))
                 .childReplyId(result.get(childReply.childReplyId))
+                .timeAgo(timeAgo)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/social/data/dto/res/FindChildReplyResDto.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FindChildReplyResDto.java
@@ -1,37 +1,21 @@
 package me.snaptime.social.data.dto.res;
 
-import com.querydsl.core.Tuple;
 import lombok.Builder;
-import me.snaptime.user.data.domain.QUser;
 
-import static me.snaptime.social.data.domain.QChildReply.childReply;
+import java.util.List;
 
 @Builder
 public record FindChildReplyResDto(
 
-        String writerLoginId,
-        String writerUserName,
-        String writerProfilePhotoURL,
-        String content,
-        String tagUserLoginId,
-        String tagUserName,
-        Long parentReplyId,
-        Long childReplyId
+        List<ChildReplyInfo> childReplyInfoList,
+        boolean hasNextPage
 
 ) {
-    public static FindChildReplyResDto toDto(Tuple result, String profilePhotoURL){
-        QUser tagUser = new QUser("tagUser");
-        QUser writerUser = new QUser("writerUser");
+    public static FindChildReplyResDto toDto(List<ChildReplyInfo> childReplyInfoList, boolean hasNextPage){
 
         return FindChildReplyResDto.builder()
-                .writerLoginId(result.get(writerUser.loginId))
-                .writerProfilePhotoURL(profilePhotoURL)
-                .writerUserName(result.get(writerUser.name))
-                .content(result.get(childReply.content))
-                .tagUserLoginId(result.get(tagUser.loginId))
-                .tagUserName(result.get(tagUser.name))
-                .parentReplyId(result.get(childReply.parentReply.parentReplyId))
-                .childReplyId(result.get(childReply.childReplyId))
+                .childReplyInfoList(childReplyInfoList)
+                .hasNextPage(hasNextPage)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/social/data/dto/res/FindFriendResDto.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FindFriendResDto.java
@@ -1,25 +1,19 @@
 package me.snaptime.social.data.dto.res;
 
-import com.querydsl.core.Tuple;
 import lombok.Builder;
 
-import static me.snaptime.social.data.domain.QFriendShip.friendShip;
-import static me.snaptime.user.data.domain.QUser.user;
+import java.util.List;
 
 @Builder
 public record FindFriendResDto(
 
-        String loginId,
-        String profilePhotoURL,
-        String userName,
-        Long friendShipId
+        List<FriendInfo> friendInfoList,
+        boolean hasNextPage
 ) {
-    public static FindFriendResDto toDto(Tuple result,String profilePhotoURL){
+    public static FindFriendResDto toDto(List<FriendInfo> friendInfoList, boolean hasNextPage){
         return FindFriendResDto.builder()
-                .loginId(result.get(user.loginId))
-                .profilePhotoURL(profilePhotoURL)
-                .userName(result.get(user.name))
-                .friendShipId(result.get(friendShip.friendShipId))
+                .friendInfoList(friendInfoList)
+                .hasNextPage(hasNextPage)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/social/data/dto/res/FindParentReplyResDto.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FindParentReplyResDto.java
@@ -1,27 +1,19 @@
 package me.snaptime.social.data.dto.res;
 
-import com.querydsl.core.Tuple;
 import lombok.Builder;
 
-import static me.snaptime.social.data.domain.QParentReply.parentReply;
-import static me.snaptime.user.data.domain.QUser.user;
+import java.util.List;
 
 @Builder
 public record FindParentReplyResDto(
 
-        String writerLoginId,
-        String writerProfilePhotoURL,
-        String writerUserName,
-        String content,
-        Long replyId
+        List<ParentReplyInfo> parentReplyInfoList,
+        boolean hasNextPage
 ) {
-    public static FindParentReplyResDto toDto(Tuple result, String profilePhotoURL){
+    public static FindParentReplyResDto toDto(List<ParentReplyInfo> parentReplyInfoList, boolean hasNextPage){
         return FindParentReplyResDto.builder()
-                .writerLoginId(result.get(user.loginId))
-                .writerProfilePhotoURL(profilePhotoURL)
-                .writerUserName(result.get(user.name))
-                .content(result.get(parentReply.content))
-                .replyId(result.get(parentReply.parentReplyId))
+                .parentReplyInfoList(parentReplyInfoList)
+                .hasNextPage(hasNextPage)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/social/data/dto/res/FriendInfo.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FriendInfo.java
@@ -1,0 +1,25 @@
+package me.snaptime.social.data.dto.res;
+
+import com.querydsl.core.Tuple;
+import lombok.Builder;
+
+import static me.snaptime.social.data.domain.QFriendShip.friendShip;
+import static me.snaptime.user.data.domain.QUser.user;
+
+@Builder
+public record FriendInfo(
+
+        String loginId,
+        String profilePhotoURL,
+        String userName,
+        Long friendShipId
+) {
+    public static FriendInfo toDto(Tuple result, String profilePhotoURL){
+        return FriendInfo.builder()
+                .loginId(result.get(user.loginId))
+                .profilePhotoURL(profilePhotoURL)
+                .userName(result.get(user.name))
+                .friendShipId(result.get(friendShip.friendShipId))
+                .build();
+    }
+}

--- a/src/main/java/me/snaptime/social/data/dto/res/ParentReplyInfo.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/ParentReplyInfo.java
@@ -13,15 +13,17 @@ public record ParentReplyInfo(
         String writerProfilePhotoURL,
         String writerUserName,
         String content,
-        Long replyId
+        Long replyId,
+        String timeAgo
 ) {
-    public static ParentReplyInfo toDto(Tuple result, String profilePhotoURL){
+    public static ParentReplyInfo toDto(Tuple result, String profilePhotoURL,String timeAgo){
         return ParentReplyInfo.builder()
                 .writerLoginId(result.get(user.loginId))
                 .writerProfilePhotoURL(profilePhotoURL)
                 .writerUserName(result.get(user.name))
                 .content(result.get(parentReply.content))
                 .replyId(result.get(parentReply.parentReplyId))
+                .timeAgo(timeAgo)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/social/data/dto/res/ParentReplyInfo.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/ParentReplyInfo.java
@@ -1,0 +1,27 @@
+package me.snaptime.social.data.dto.res;
+
+import com.querydsl.core.Tuple;
+import lombok.Builder;
+
+import static me.snaptime.social.data.domain.QParentReply.parentReply;
+import static me.snaptime.user.data.domain.QUser.user;
+
+@Builder
+public record ParentReplyInfo(
+
+        String writerLoginId,
+        String writerProfilePhotoURL,
+        String writerUserName,
+        String content,
+        Long replyId
+) {
+    public static ParentReplyInfo toDto(Tuple result, String profilePhotoURL){
+        return ParentReplyInfo.builder()
+                .writerLoginId(result.get(user.loginId))
+                .writerProfilePhotoURL(profilePhotoURL)
+                .writerUserName(result.get(user.name))
+                .content(result.get(parentReply.content))
+                .replyId(result.get(parentReply.parentReplyId))
+                .build();
+    }
+}

--- a/src/main/java/me/snaptime/social/data/repository/friendShip/impl/FriendShipPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/social/data/repository/friendShip/impl/FriendShipPagingRepositoryImpl.java
@@ -29,7 +29,7 @@ public class FriendShipPagingRepositoryImpl implements FriendShipPagingRepositor
 
     @Override
     public List<Tuple> findFriendList(User reqUser, FriendSearchType searchType, Long pageNum, String searchKeyword) {
-        Pageable pageable= PageRequest.of((int) (pageNum-1),30);
+        Pageable pageable= PageRequest.of((int) (pageNum-1),20);
 
         List<Tuple> result =  jpaQueryFactory.select(
                         user.loginId,user.profilePhoto.id,user.name,friendShip.friendShipId
@@ -39,7 +39,7 @@ public class FriendShipPagingRepositoryImpl implements FriendShipPagingRepositor
                 .where(getWhereBuilder(reqUser, searchType,searchKeyword))
                 .orderBy(createOrderSpecifier())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize()) //페이지의 크기
+                .limit(pageable.getPageSize()+1) //페이지의 크기
                 .fetch();
 
         if(result.size() == 0)

--- a/src/main/java/me/snaptime/social/data/repository/reply/impl/ChildReplyPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/social/data/repository/reply/impl/ChildReplyPagingRepositoryImpl.java
@@ -42,7 +42,7 @@ public class ChildReplyPagingRepositoryImpl implements ChildReplyPagingRepositor
                 .where(childReply.parentReply.parentReplyId.eq(parentReplyId))
                 .orderBy(createOrderSpecifier())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize()) //페이지의 크기
+                .limit(pageable.getPageSize()+1) //페이지의 크기
                 .fetch();
 
         if(result.size() == 0)

--- a/src/main/java/me/snaptime/social/data/repository/reply/impl/ParentReplyPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/social/data/repository/reply/impl/ParentReplyPagingRepositoryImpl.java
@@ -29,7 +29,7 @@ public class ParentReplyPagingRepositoryImpl implements ParentReplyPagingReposit
 
         List<Tuple> result =  jpaQueryFactory.select(
                         user.loginId,user.profilePhoto.id,user.name,
-                        parentReply.content,parentReply.parentReplyId
+                        parentReply.content,parentReply.parentReplyId,parentReply.lastModifiedDate
                 )
                 .from(parentReply)
                 .join(user).on(parentReply.user.id.eq(user.id))

--- a/src/main/java/me/snaptime/social/data/repository/reply/impl/ParentReplyPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/social/data/repository/reply/impl/ParentReplyPagingRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ParentReplyPagingRepositoryImpl implements ParentReplyPagingReposit
                 .where(parentReply.snap.id.eq(snapId))
                 .orderBy(createOrderSpecifier())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize()) //페이지의 크기
+                .limit(pageable.getPageSize()+1) //페이지의 크기
                 .fetch();
 
         if(result.size() == 0)

--- a/src/main/java/me/snaptime/social/service/FriendShipService.java
+++ b/src/main/java/me/snaptime/social/service/FriendShipService.java
@@ -3,7 +3,7 @@ package me.snaptime.social.service;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.common.component.UrlComponent;
-import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
+import me.snaptime.common.component.impl.NextPageChecker;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.social.common.FriendSearchType;
@@ -33,7 +33,7 @@ public class FriendShipService {
     private final FriendShipRepository friendShipRepository;
     private final UserRepository userRepository;
     private final UrlComponent urlComponent;
-    private final CheckNextPageComponentImpl checkNextPageComponent;
+    private final NextPageChecker nextPageChecker;
 
     // 친구요청 전송(fromUser(요청자)의 팔로잉 +1, toUser의 팔로워 +1)
     @Transactional
@@ -121,7 +121,7 @@ public class FriendShipService {
 
         User reqUser = findUserByLoginId(loginId);
         List<Tuple> result = friendShipRepository.findFriendList(reqUser,searchType,pageNum,searchKeyword);
-        boolean hasNextPage = checkNextPageComponent.hasNextPage(result,20L);
+        boolean hasNextPage = nextPageChecker.hasNextPage(result,20L);
         if(hasNextPage)
             result.remove(20);
 

--- a/src/main/java/me/snaptime/social/service/FriendShipService.java
+++ b/src/main/java/me/snaptime/social/service/FriendShipService.java
@@ -3,6 +3,7 @@ package me.snaptime.social.service;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.common.component.UrlComponent;
+import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.social.common.FriendSearchType;
@@ -11,6 +12,7 @@ import me.snaptime.social.data.domain.FriendShip;
 import me.snaptime.social.data.dto.req.AcceptFollowReqDto;
 import me.snaptime.social.data.dto.res.FindFriendResDto;
 import me.snaptime.social.data.dto.res.FriendCntResDto;
+import me.snaptime.social.data.dto.res.FriendInfo;
 import me.snaptime.social.data.repository.friendShip.FriendShipRepository;
 import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.repository.UserRepository;
@@ -31,6 +33,7 @@ public class FriendShipService {
     private final FriendShipRepository friendShipRepository;
     private final UserRepository userRepository;
     private final UrlComponent urlComponent;
+    private final CheckNextPageComponentImpl checkNextPageComponent;
 
     // 친구요청 전송(fromUser(요청자)의 팔로잉 +1, toUser의 팔로워 +1)
     @Transactional
@@ -114,15 +117,21 @@ public class FriendShipService {
     }
     
     // 팔로워 or 팔로잉 친구리스트 조회
-    public List<FindFriendResDto> findFriendList(String loginId, Long pageNum, FriendSearchType searchType, String searchKeyword){
+    public FindFriendResDto findFriendList(String loginId, Long pageNum, FriendSearchType searchType, String searchKeyword){
 
         User reqUser = findUserByLoginId(loginId);
         List<Tuple> result = friendShipRepository.findFriendList(reqUser,searchType,pageNum,searchKeyword);
+        boolean hasNextPage = checkNextPageComponent.hasNextPage(result,20L);
+        if(hasNextPage)
+            result.remove(20);
 
-        return result.stream().map(entity -> {
+        List<FriendInfo> friendInfoList = result.stream().map(entity ->
+        {
             String profilePhotoURL = urlComponent.makeProfileURL(entity.get(user.profilePhoto.id));
-            return FindFriendResDto.toDto(entity,profilePhotoURL);
+            return FriendInfo.toDto(entity,profilePhotoURL);
         }).collect(Collectors.toList());
+
+        return FindFriendResDto.toDto(friendInfoList, hasNextPage);
     }
 
     // 유저 프로필 조회 시 팔로잉,팔로워 수를 반환하는 메소드

--- a/src/main/java/me/snaptime/social/service/ReplyService.java
+++ b/src/main/java/me/snaptime/social/service/ReplyService.java
@@ -3,6 +3,7 @@ package me.snaptime.social.service;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.common.component.UrlComponent;
+import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.snap.data.domain.Snap;
@@ -11,8 +12,10 @@ import me.snaptime.social.data.domain.ChildReply;
 import me.snaptime.social.data.domain.ParentReply;
 import me.snaptime.social.data.dto.req.AddChildReplyReqDto;
 import me.snaptime.social.data.dto.req.AddParentReplyReqDto;
+import me.snaptime.social.data.dto.res.ChildReplyInfo;
 import me.snaptime.social.data.dto.res.FindChildReplyResDto;
 import me.snaptime.social.data.dto.res.FindParentReplyResDto;
+import me.snaptime.social.data.dto.res.ParentReplyInfo;
 import me.snaptime.social.data.repository.reply.ChildReplyRepository;
 import me.snaptime.social.data.repository.reply.ParentReplyRepository;
 import me.snaptime.user.data.domain.QUser;
@@ -36,6 +39,7 @@ public class ReplyService {
     private final UserRepository userRepository;
     private final SnapRepository snapRepository;
     private final UrlComponent urlComponent;
+    private final CheckNextPageComponentImpl checkNextPageComponent;
 
     @Transactional
     public void addParentReply(String loginId, AddParentReplyReqDto addParentReplyReqDto){
@@ -72,24 +76,37 @@ public class ReplyService {
         );
     }
 
-    public List<FindParentReplyResDto> readParentReply(String loginId, Long snapId, Long pageNum){
+    public FindParentReplyResDto readParentReply(String loginId, Long snapId, Long pageNum){
 
         List<Tuple> result = parentReplyRepository.findReplyList(loginId,snapId,pageNum);
+        boolean hasNextPage = checkNextPageComponent.hasNextPage(result,20L);
+        if(hasNextPage)
+            result.remove(20);
 
-        return result.stream().map(entity -> {
+        List<ParentReplyInfo> parentReplyInfoList = result.stream().map(entity ->
+        {
             String profilePhotoURL = urlComponent.makeProfileURL(entity.get(user.profilePhoto.id));
-            return FindParentReplyResDto.toDto(entity,profilePhotoURL);
+            return ParentReplyInfo.toDto(entity,profilePhotoURL);
         }).collect(Collectors.toList());
+
+        return FindParentReplyResDto.toDto(parentReplyInfoList, hasNextPage);
     }
 
-    public List<FindChildReplyResDto> readChildReply(String loginId, Long parentReplyId, Long pageNum){
+    public FindChildReplyResDto readChildReply(String loginId, Long parentReplyId, Long pageNum){
+
         QUser writerUser = new QUser("writerUser");
         List<Tuple> result = childReplyRepository.findReplyList(loginId,parentReplyId,pageNum);
+        boolean hasNextPage = checkNextPageComponent.hasNextPage(result,20L);
+        if(hasNextPage)
+            result.remove(20);
 
-        return result.stream().map(entity -> {
+        List<ChildReplyInfo> childReplyInfoList = result.stream().map(entity ->
+        {
             String profilePhotoURL = urlComponent.makeProfileURL(entity.get(writerUser.profilePhoto.id));
-            return FindChildReplyResDto.toDto(entity,profilePhotoURL);
+            return ChildReplyInfo.toDto(entity,profilePhotoURL);
         }).collect(Collectors.toList());
+
+        return FindChildReplyResDto.toDto(childReplyInfoList, hasNextPage);
     }
 
     @Transactional

--- a/src/main/java/me/snaptime/user/service/UserService.java
+++ b/src/main/java/me/snaptime/user/service/UserService.java
@@ -27,7 +27,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/test/java/me/snaptime/snap/controller/SnapPagingControllerTest.java
+++ b/src/test/java/me/snaptime/snap/controller/SnapPagingControllerTest.java
@@ -45,7 +45,7 @@ public class SnapPagingControllerTest {
         //given
 
         //when, then
-        this.mockMvc.perform(get("/snaps/community/{pageNum}",1L)
+        this.mockMvc.perform(get("/community/snaps/{pageNum}",1L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("스냅 페이징조회가 완료되었습니다."))
@@ -61,7 +61,7 @@ public class SnapPagingControllerTest {
         //given
 
         //when, then
-        this.mockMvc.perform(get("/snaps/community/{pageNum}","test")
+        this.mockMvc.perform(get("/community/snaps/{pageNum}","test")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.msg").value("pageNum이 Long타입이여야 합니다."))
@@ -79,7 +79,7 @@ public class SnapPagingControllerTest {
                 .willThrow(new CustomException(ExceptionCode.PAGE_NOT_FOUND));
 
         //when, then
-        this.mockMvc.perform(get("/snaps/community/{pageNum}",1L)
+        this.mockMvc.perform(get("/community/snaps/{pageNum}",1L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.msg").value("존재하지 않는 페이지입니다."))

--- a/src/test/java/me/snaptime/snap/service/SnapPagingServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/SnapPagingServiceImplTest.java
@@ -2,6 +2,7 @@ package me.snaptime.snap.service;
 
 import com.querydsl.core.Tuple;
 import me.snaptime.common.component.UrlComponent;
+import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
 import me.snaptime.snap.data.dto.res.FindSnapPagingResDto;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.snap.service.impl.SnapPagingServiceImpl;
@@ -42,6 +43,8 @@ public class SnapPagingServiceImplTest {
     private SnapTagService snapTagService;
     @Mock
     private SnapLikeService snapLikeService;
+    @Mock
+    private CheckNextPageComponentImpl checkNextPageComponent;
     private User reqUser;
 
     @BeforeEach
@@ -81,21 +84,21 @@ public class SnapPagingServiceImplTest {
         given(snapRepository.findSnapPaging(any(String.class),any(Long.class),any(User.class))).willReturn(List.of(tuple1,tuple2,tuple3));
 
         // when
-        List<FindSnapPagingResDto> result = snapPagingService.findSnapPaging("testLoginId",1L);
+        FindSnapPagingResDto result = snapPagingService.findSnapPaging("testLoginId",1L);
 
         // then
-        assertThat(result.size()).isEqualTo(3);
-        assertThat(result.get(0).snapId()).isEqualTo(1);
-        assertThat(result.get(1).snapId()).isEqualTo(2);
-        assertThat(result.get(2).snapId()).isEqualTo(3);
+        assertThat(result.snapPagingInfoList().size()).isEqualTo(3);
+        assertThat(result.snapPagingInfoList().get(0).snapId()).isEqualTo(1);
+        assertThat(result.snapPagingInfoList().get(1).snapId()).isEqualTo(2);
+        assertThat(result.snapPagingInfoList().get(2).snapId()).isEqualTo(3);
 
-        assertThat(result.get(0).oneLineJournal()).isEqualTo("일기1");
-        assertThat(result.get(1).oneLineJournal()).isEqualTo("일기2");
-        assertThat(result.get(2).oneLineJournal()).isEqualTo("일기3");
+        assertThat(result.snapPagingInfoList().get(0).oneLineJournal()).isEqualTo("일기1");
+        assertThat(result.snapPagingInfoList().get(1).oneLineJournal()).isEqualTo("일기2");
+        assertThat(result.snapPagingInfoList().get(2).oneLineJournal()).isEqualTo("일기3");
 
-        assertThat(result.get(0).snapPhotoURL()).isEqualTo("photoURL1");
-        assertThat(result.get(1).snapPhotoURL()).isEqualTo("photoURL2");
-        assertThat(result.get(2).snapPhotoURL()).isEqualTo("photoURL3");
+        assertThat(result.snapPagingInfoList().get(0).snapPhotoURL()).isEqualTo("photoURL1");
+        assertThat(result.snapPagingInfoList().get(1).snapPhotoURL()).isEqualTo("photoURL2");
+        assertThat(result.snapPagingInfoList().get(2).snapPhotoURL()).isEqualTo("photoURL3");
 
         verify(snapRepository,times(1)).findSnapPaging(any(String.class),any(Long.class),any(User.class));
         verify(userRepository,times(1)).findByLoginId(any(String.class));

--- a/src/test/java/me/snaptime/snap/service/SnapPagingServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/SnapPagingServiceImplTest.java
@@ -2,7 +2,7 @@ package me.snaptime.snap.service;
 
 import com.querydsl.core.Tuple;
 import me.snaptime.common.component.UrlComponent;
-import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
+import me.snaptime.common.component.impl.NextPageChecker;
 import me.snaptime.snap.data.dto.res.FindSnapPagingResDto;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.snap.service.impl.SnapPagingServiceImpl;
@@ -44,7 +44,7 @@ public class SnapPagingServiceImplTest {
     @Mock
     private SnapLikeService snapLikeService;
     @Mock
-    private CheckNextPageComponentImpl checkNextPageComponent;
+    private NextPageChecker nextPageChecker;
     private User reqUser;
 
     @BeforeEach

--- a/src/test/java/me/snaptime/social/controller/FriendShipControllerTest.java
+++ b/src/test/java/me/snaptime/social/controller/FriendShipControllerTest.java
@@ -335,6 +335,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWING")
+                        .param("loginId","tempLoginId")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("친구조회가 완료되었습니다."))
@@ -353,6 +354,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWER")
+                        .param("loginId","tempLoginId")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("친구조회가 완료되었습니다."))
@@ -371,6 +373,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWING")
+                        .param("loginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -390,6 +393,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","TEST")
+                        .param("loginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -409,6 +413,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}","test")
                         .param("friendSearchType","FOLLOWER")
+                        .param("loginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -428,6 +433,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","")
+                        .param("loginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -449,6 +455,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWER")
+                        .param("loginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())

--- a/src/test/java/me/snaptime/social/service/FriendShipServiceTest.java
+++ b/src/test/java/me/snaptime/social/service/FriendShipServiceTest.java
@@ -2,6 +2,7 @@ package me.snaptime.social.service;
 
 import com.querydsl.core.Tuple;
 import me.snaptime.common.component.UrlComponent;
+import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.social.common.FriendSearchType;
@@ -42,6 +43,8 @@ public class FriendShipServiceTest {
     private UserRepository userRepository;
     @Mock
     private UrlComponent urlComponent;
+    @Mock
+    private CheckNextPageComponentImpl checkNextPageComponent;
 
     private FriendShip friendShip;
     private User user1;
@@ -362,21 +365,23 @@ public class FriendShipServiceTest {
                 .willReturn(List.of(tuple1,tuple2,tuple3));
 
         // when
-        List<FindFriendResDto> result = friendShipService
+        FindFriendResDto result = friendShipService
                 .findFriendList("loginId",1L,FriendSearchType.FOLLOWER,"searchKeyword");
 
         // then
-        assertThat(result.get(0).loginId()).isEqualTo("testLoginId1");
-        assertThat(result.get(1).loginId()).isEqualTo("testLoginId2");
-        assertThat(result.get(2).loginId()).isEqualTo("testLoginId3");
+        assertThat(result.friendInfoList().get(0).loginId()).isEqualTo("testLoginId1");
+        assertThat(result.friendInfoList().get(1).loginId()).isEqualTo("testLoginId2");
+        assertThat(result.friendInfoList().get(2).loginId()).isEqualTo("testLoginId3");
 
-        assertThat(result.get(0).userName()).isEqualTo("name1");
-        assertThat(result.get(1).userName()).isEqualTo("name2");
-        assertThat(result.get(2).userName()).isEqualTo("name3");
+        assertThat(result.friendInfoList().get(0).userName()).isEqualTo("name1");
+        assertThat(result.friendInfoList().get(1).userName()).isEqualTo("name2");
+        assertThat(result.friendInfoList().get(2).userName()).isEqualTo("name3");
 
-        assertThat(result.get(0).profilePhotoURL()).isEqualTo("profile1");
-        assertThat(result.get(1).profilePhotoURL()).isEqualTo("profile2");
-        assertThat(result.get(2).profilePhotoURL()).isEqualTo("profile3");
+        assertThat(result.friendInfoList().get(0).profilePhotoURL()).isEqualTo("profile1");
+        assertThat(result.friendInfoList().get(1).profilePhotoURL()).isEqualTo("profile2");
+        assertThat(result.friendInfoList().get(2).profilePhotoURL()).isEqualTo("profile3");
+
+        assertThat(result.hasNextPage()).isFalse();
 
         verify(userRepository,times(1)).findByLoginId(any(String.class));
         verify(urlComponent,times(3)).makeProfileURL(any(Long.class));

--- a/src/test/java/me/snaptime/social/service/FriendShipServiceTest.java
+++ b/src/test/java/me/snaptime/social/service/FriendShipServiceTest.java
@@ -2,7 +2,7 @@ package me.snaptime.social.service;
 
 import com.querydsl.core.Tuple;
 import me.snaptime.common.component.UrlComponent;
-import me.snaptime.common.component.impl.CheckNextPageComponentImpl;
+import me.snaptime.common.component.impl.NextPageChecker;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.social.common.FriendSearchType;
@@ -44,7 +44,7 @@ public class FriendShipServiceTest {
     @Mock
     private UrlComponent urlComponent;
     @Mock
-    private CheckNextPageComponentImpl checkNextPageComponent;
+    private NextPageChecker nextPageChecker;
 
     private FriendShip friendShip;
     private User user1;

--- a/src/test/java/me/snaptime/social/service/ReplyServiceTest.java
+++ b/src/test/java/me/snaptime/social/service/ReplyServiceTest.java
@@ -1,5 +1,7 @@
 package me.snaptime.social.service;
 
+import me.snaptime.common.component.impl.NextPageChecker;
+import me.snaptime.common.component.impl.TimeAgoCalculator;
 import me.snaptime.common.exception.customs.CustomException;
 import me.snaptime.common.exception.customs.ExceptionCode;
 import me.snaptime.snap.data.domain.Snap;
@@ -42,6 +44,10 @@ public class ReplyServiceTest {
     private UserRepository userRepository;
     @Mock
     private SnapRepository snapRepository;
+    @Mock
+    private NextPageChecker nextPageChecker;
+    @Mock
+    private TimeAgoCalculator timeAgoCalculator;
 
     private User user;
     private Snap snap;


### PR DESCRIPTION
## 📋 이슈 번호
close #81 

## 🛠 구현 사항
1. 페이징 조회 시 다음 페이지 유무를 반환합니다.
2. 댓글조회 시 시간정보를 반환합니다.
3. 자기자신의 친구목록만 조회가 가능했던 문제를 해결합니다.


## 📚 기타
