### PR TITLE
[Feat,Fix] 알림 테이블 추가 & 친구조회 수정 & 스냅조회 수정 & 대댓글 등록 버그 수정

### DIFF
--- a/src/main/generated/me/snaptime/social/data/domain/QFriendAlarm.java
+++ b/src/main/generated/me/snaptime/social/data/domain/QFriendAlarm.java
@@ -1,0 +1,58 @@
+package me.snaptime.social.data.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QFriendAlarm is a Querydsl query type for FriendAlarm
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFriendAlarm extends EntityPathBase<FriendAlarm> {
+
+    private static final long serialVersionUID = 2130010669L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QFriendAlarm friendAlarm = new QFriendAlarm("friendAlarm");
+
+    public final EnumPath<me.snaptime.social.common.AlarmType> alarmType = createEnum("alarmType", me.snaptime.social.common.AlarmType.class);
+
+    public final me.snaptime.user.data.domain.QUser fromUser;
+
+    public final BooleanPath isRead = createBoolean("isRead");
+
+    public final NumberPath<Long> snapAlarmId = createNumber("snapAlarmId", Long.class);
+
+    public final me.snaptime.user.data.domain.QUser toUser;
+
+    public QFriendAlarm(String variable) {
+        this(FriendAlarm.class, forVariable(variable), INITS);
+    }
+
+    public QFriendAlarm(Path<? extends FriendAlarm> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QFriendAlarm(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QFriendAlarm(PathMetadata metadata, PathInits inits) {
+        this(FriendAlarm.class, metadata, inits);
+    }
+
+    public QFriendAlarm(Class<? extends FriendAlarm> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.fromUser = inits.isInitialized("fromUser") ? new me.snaptime.user.data.domain.QUser(forProperty("fromUser"), inits.get("fromUser")) : null;
+        this.toUser = inits.isInitialized("toUser") ? new me.snaptime.user.data.domain.QUser(forProperty("toUser"), inits.get("toUser")) : null;
+    }
+
+}
+

--- a/src/main/generated/me/snaptime/social/data/domain/QSnapAlarm.java
+++ b/src/main/generated/me/snaptime/social/data/domain/QSnapAlarm.java
@@ -1,0 +1,69 @@
+package me.snaptime.social.data.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSnapAlarm is a Querydsl query type for SnapAlarm
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSnapAlarm extends EntityPathBase<SnapAlarm> {
+
+    private static final long serialVersionUID = -925890815L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSnapAlarm snapAlarm = new QSnapAlarm("snapAlarm");
+
+    public final me.snaptime.common.domain.QBaseTimeEntity _super = new me.snaptime.common.domain.QBaseTimeEntity(this);
+
+    public final EnumPath<me.snaptime.social.common.AlarmType> alarmType = createEnum("alarmType", me.snaptime.social.common.AlarmType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+
+    public final me.snaptime.user.data.domain.QUser fromUser;
+
+    public final BooleanPath isRead = createBoolean("isRead");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+
+    public final me.snaptime.snap.data.domain.QSnap snap;
+
+    public final NumberPath<Long> snapAlarmId = createNumber("snapAlarmId", Long.class);
+
+    public final me.snaptime.user.data.domain.QUser toUser;
+
+    public QSnapAlarm(String variable) {
+        this(SnapAlarm.class, forVariable(variable), INITS);
+    }
+
+    public QSnapAlarm(Path<? extends SnapAlarm> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSnapAlarm(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSnapAlarm(PathMetadata metadata, PathInits inits) {
+        this(SnapAlarm.class, metadata, inits);
+    }
+
+    public QSnapAlarm(Class<? extends SnapAlarm> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.fromUser = inits.isInitialized("fromUser") ? new me.snaptime.user.data.domain.QUser(forProperty("fromUser"), inits.get("fromUser")) : null;
+        this.snap = inits.isInitialized("snap") ? new me.snaptime.snap.data.domain.QSnap(forProperty("snap"), inits.get("snap")) : null;
+        this.toUser = inits.isInitialized("toUser") ? new me.snaptime.user.data.domain.QUser(forProperty("toUser"), inits.get("toUser")) : null;
+    }
+
+}
+

--- a/src/main/java/me/snaptime/common/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/me/snaptime/common/exception/handler/CustomExceptionHandler.java
@@ -96,4 +96,13 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler{
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new CommonResponseDto(message,null));
     }
 
+    // 기타예외 발생 시 500반환
+    @ExceptionHandler
+    public ResponseEntity<CommonResponseDto> handleException(Exception ex) {
+
+        String message = "서버 내부에 에러가 발생했습니다.";
+        log.error(message+":"+ex.getMessage()+ex.getStackTrace()+ex.getCause());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new CommonResponseDto(message,null));
+    }
+
 }

--- a/src/main/java/me/snaptime/snap/data/dto/res/FindSnapPagingResDto.java
+++ b/src/main/java/me/snaptime/snap/data/dto/res/FindSnapPagingResDto.java
@@ -11,6 +11,7 @@ public record FindSnapPagingResDto(
     boolean hasNextPage
 ) {
     public static FindSnapPagingResDto toDto(List<SnapPagingInfo> snapPagingInfoList, boolean hasNextPage){
+
         return FindSnapPagingResDto.builder()
                 .snapPagingInfoList(snapPagingInfoList)
                 .hasNextPage(hasNextPage)

--- a/src/main/java/me/snaptime/snap/data/dto/res/SnapPagingInfo.java
+++ b/src/main/java/me/snaptime/snap/data/dto/res/SnapPagingInfo.java
@@ -22,10 +22,11 @@ public record SnapPagingInfo(
         String profilePhotoURL,
         String userName,
         List<FindTagUserResDto> findTagUserList,
-        Long likeCnt
+        Long likeCnt,
+        boolean isLikedSnap
 ) {
     public static SnapPagingInfo toDto(Tuple result, String profilePhotoURL, String snapPhotoURL,
-                                             List<FindTagUserResDto> findTagUserList, Long likeCnt){
+                                       List<FindTagUserResDto> findTagUserList, Long likeCnt, boolean isLikedSnap){
         return SnapPagingInfo.builder()
                 .snapId(result.get(snap.id))
                 .oneLineJournal(String.valueOf(result.get(snap.oneLineJournal)))
@@ -37,6 +38,7 @@ public record SnapPagingInfo(
                 .userName(result.get(user.name))
                 .findTagUserList(findTagUserList)
                 .likeCnt(likeCnt)
+                .isLikedSnap(isLikedSnap)
                 .build();
     }
 

--- a/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
@@ -52,7 +52,8 @@ public class SnapPagingServiceImpl {
 
             return SnapPagingInfo.toDto(entity,profilePhotoURL,snapPhotoURL,
                     snapTagService.findTagUserList(snapId),
-                    snapLikeService.findSnapLikeCnt(snapId));
+                    snapLikeService.findSnapLikeCnt(snapId),
+                    snapLikeService.isLikedSnap(snapId, loginId));
         }).collect(Collectors.toList());
 
         return FindSnapPagingResDto.toDto(snapPagingInfoList, hasNextPage);

--- a/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
+++ b/src/main/java/me/snaptime/snap/service/impl/SnapPagingServiceImpl.java
@@ -56,7 +56,7 @@ public class SnapPagingServiceImpl {
                     snapLikeService.isLikedSnap(snapId, loginId));
         }).collect(Collectors.toList());
 
-        return FindSnapPagingResDto.toDto(snapPagingInfoList, hasNextPage);
+        return FindSnapPagingResDto.toDto(snapPagingInfoList,hasNextPage);
     }
 
 }

--- a/src/main/java/me/snaptime/social/common/AlarmType.java
+++ b/src/main/java/me/snaptime/social/common/AlarmType.java
@@ -1,0 +1,9 @@
+package me.snaptime.social.common;
+
+public enum AlarmType {
+
+    REPLY,
+    TAG,
+    LIKE,
+    FOLLOW
+}

--- a/src/main/java/me/snaptime/social/controller/FriendShipController.java
+++ b/src/main/java/me/snaptime/social/controller/FriendShipController.java
@@ -70,19 +70,20 @@ public class FriendShipController {
                     "<br>검색키워드는 필수가 아니며 없으면 입력하지 않아도 됩니다." +
                     "<br>스냅에 친구를 태그하기 위해 태그할 유저 조회를 할 경우 friendSearchType을 팔로잉으로 보내시면 됩니다.")
     @Parameters({
-            @Parameter(name = "loginId" , description = "친구목록을 조회할 유저의 loginId", required = true,example = "tempLoginId"),
+            @Parameter(name = "targetLoginId" , description = "친구목록을 조회할 유저의 loginId", required = true,example = "tempLoginId"),
             @Parameter(name = "searchKeyword", description = "친구 검색키워드", required = false, example = "홍길동"),
             @Parameter(name = "friendSearchType", description = "검색 타입(팔로워 조회 시 FOLLOWER/팔로잉 조회 시 FOLLOWING)으로 입력해주세요.", required = true, example = "FOLLOWER"),
             @Parameter(name = "pageNum", description = "친구조회 페이지번호", required = true, example = "1")
     })
     public ResponseEntity<CommonResponseDto<FindFriendResDto>> findFriendList(
-            @RequestParam(name = "loginId") @NotBlank(message = "친구목록을 조회할 유저의 loginId를 입력해주세요.") String loginId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(name = "targetLoginId") @NotBlank(message = "친구목록을 조회할 유저의 loginId를 입력해주세요.") String loginId,
             @RequestParam(name = "friendSearchType") @NotNull(message = "팔로우,팔로잉중 하나를 입력해주세요.") FriendSearchType friendSearchType,
             @RequestParam(name = "searchKeyword",required = false) String searchKeyword,
             @PathVariable(name = "pageNum") final Long pageNum){
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto("친구조회가 완료되었습니다.",
-                friendShipService.findFriendList(loginId,pageNum,friendSearchType,searchKeyword)));
+                friendShipService.findFriendList(userDetails.getUsername(), loginId,pageNum,friendSearchType,searchKeyword)));
     }
 
 }

--- a/src/main/java/me/snaptime/social/controller/FriendShipController.java
+++ b/src/main/java/me/snaptime/social/controller/FriendShipController.java
@@ -53,7 +53,7 @@ public class FriendShipController {
     }
 
     @DeleteMapping("/{friendShipId}")
-    @Operation(summary = "팔로우하는 친구삭제", description = "팔로우요청을 수락or거절할 유저의 이름을 입력해주세요.<br>fromUser(삭제자)의 팔로잉 -1, toUser의 팔로워 -1")
+    @Operation(summary = "팔로우하는 친구삭제", description = "언팔로우 할 친구의 friendShipId를 보내주세요.<br>fromUser(삭제자)의 팔로잉 -1, toUser의 팔로워 -1")
     @Parameter(name = "friendShipId", description = "팔로우 삭제할 친구관계 id", required = true, example = "1")
     public ResponseEntity<CommonResponseDto<Void>> deleteFollow(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/me/snaptime/social/data/domain/FriendAlarm.java
+++ b/src/main/java/me/snaptime/social/data/domain/FriendAlarm.java
@@ -1,0 +1,51 @@
+package me.snaptime.social.data.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.snaptime.social.common.AlarmType;
+import me.snaptime.user.data.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FriendAlarm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long snapAlarmId;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "to_user_id")
+    // 알림을 받는 유저
+    private User toUser;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "from_user_id")
+    // 행위(팔로잉 요청)를 통해서 toUser에게 알림이 가도록 하는 유저
+    private User fromUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "alarm_type")
+    private AlarmType alarmType;
+
+    @Column(name = "is_read",nullable = false)
+    private boolean isRead = false;
+
+    @Builder
+    protected FriendAlarm(User toUser, User fromUser, AlarmType alarmType){
+        this.toUser=toUser;
+        this.fromUser=fromUser;
+        this.alarmType=alarmType;
+    }
+
+    public void readAlarm(){
+        isRead = true;
+    }
+}

--- a/src/main/java/me/snaptime/social/data/domain/SnapAlarm.java
+++ b/src/main/java/me/snaptime/social/data/domain/SnapAlarm.java
@@ -1,0 +1,59 @@
+package me.snaptime.social.data.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.snaptime.common.domain.BaseTimeEntity;
+import me.snaptime.snap.data.domain.Snap;
+import me.snaptime.social.common.AlarmType;
+import me.snaptime.user.data.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SnapAlarm extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long snapAlarmId;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name="snap_id",nullable = false)
+    private Snap snap;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "to_user_id")
+    // 알림을 받는 유저
+    private User toUser;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "from_user_id")
+    // 행위(좋아요 누르기, 댓글달기 등)를 통해서 toUser에게 알림이 가도록 하는 유저
+    private User fromUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "alarm_type")
+    private AlarmType alarmType;
+
+    @Column(name = "is_read",nullable = false)
+    private boolean isRead = false;
+
+    @Builder
+    protected SnapAlarm(Snap snap, User toUser, User fromUser, AlarmType alarmType){
+        this.toUser=toUser;
+        this.fromUser=fromUser;
+        this.snap = snap;
+        this.alarmType=alarmType;
+    }
+
+    public void readAlarm(){
+        isRead = true;
+    }
+}

--- a/src/main/java/me/snaptime/social/data/dto/res/FriendInfo.java
+++ b/src/main/java/me/snaptime/social/data/dto/res/FriendInfo.java
@@ -12,14 +12,16 @@ public record FriendInfo(
         String loginId,
         String profilePhotoURL,
         String userName,
-        Long friendShipId
+        Long friendShipId,
+        boolean isMyFriend
 ) {
-    public static FriendInfo toDto(Tuple result, String profilePhotoURL){
+    public static FriendInfo toDto(Tuple result, String profilePhotoURL, boolean isMyFriend){
         return FriendInfo.builder()
                 .loginId(result.get(user.loginId))
                 .profilePhotoURL(profilePhotoURL)
                 .userName(result.get(user.name))
                 .friendShipId(result.get(friendShip.friendShipId))
+                .isMyFriend(isMyFriend)
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/social/data/repository/alarm/FriendAlarmRepository.java
+++ b/src/main/java/me/snaptime/social/data/repository/alarm/FriendAlarmRepository.java
@@ -1,0 +1,7 @@
+package me.snaptime.social.data.repository.alarm;
+
+import me.snaptime.social.data.domain.FriendAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendAlarmRepository extends JpaRepository<FriendAlarm,Long> {
+}

--- a/src/main/java/me/snaptime/social/data/repository/alarm/SnapAlarmRepository.java
+++ b/src/main/java/me/snaptime/social/data/repository/alarm/SnapAlarmRepository.java
@@ -1,0 +1,8 @@
+package me.snaptime.social.data.repository.alarm;
+
+import me.snaptime.social.data.domain.SnapAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SnapAlarmRepository extends JpaRepository<SnapAlarm,Long> {
+
+}

--- a/src/main/java/me/snaptime/social/data/repository/friendShip/FriendShipRepository.java
+++ b/src/main/java/me/snaptime/social/data/repository/friendShip/FriendShipRepository.java
@@ -15,4 +15,6 @@ public interface FriendShipRepository extends JpaRepository<FriendShip,Long>, Fr
 
     // 나를 팔로우 하는 사람의 수
     Long countByToUserAndFriendStatus(User toUser, FriendStatus friendStatus);
+
+    boolean existsByToUserAndFromUser(User toUser, User fromUser);
 }

--- a/src/main/java/me/snaptime/social/data/repository/snapLike/SnapLikeRepository.java
+++ b/src/main/java/me/snaptime/social/data/repository/snapLike/SnapLikeRepository.java
@@ -11,5 +11,7 @@ public interface SnapLikeRepository extends JpaRepository<SnapLike,Long> {
 
     Optional<SnapLike> findBySnapAndUser(Snap snap, User user);
 
+    boolean existsBySnapAndUser(Snap snap, User user);
+
     Long countBySnap(Snap snap);
 }

--- a/src/main/java/me/snaptime/social/service/ReplyService.java
+++ b/src/main/java/me/snaptime/social/service/ReplyService.java
@@ -63,21 +63,35 @@ public class ReplyService {
     @Transactional
     public void addChildReply(String loginId, AddChildReplyReqDto addChildReplyReqDto){
         User user = findUserByLoginId(loginId);
-        User tagUser = userRepository.findByLoginId(addChildReplyReqDto.tagLoginId())
-                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
         ParentReply parentReply = parentReplyRepository.findById(addChildReplyReqDto.parentReplyId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.REPLY_NOT_FOUND));
 
+        // 태그유저가 없는 댓글 등록이면
+        if( addChildReplyReqDto.tagLoginId() == "" || addChildReplyReqDto.tagLoginId() == null){
+            childReplyRepository.save(
+                    ChildReply.builder()
+                            .parentReply(parentReply)
+                            .user(user)
+                            .content(addChildReplyReqDto.content())
+                            .build()
+            );
+
+            return ;
+        }
+
+        User tagUser = userRepository.findByLoginId(addChildReplyReqDto.tagLoginId())
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
 
         childReplyRepository.save(
                 ChildReply.builder()
                         .parentReply(parentReply)
-                        .tagUser(tagUser)
                         .user(user)
+                        .tagUser(tagUser)
                         .content(addChildReplyReqDto.content())
                         .build()
         );
+
     }
 
     public FindParentReplyResDto readParentReply(String loginId, Long snapId, Long pageNum){

--- a/src/main/java/me/snaptime/social/service/SnapLikeService.java
+++ b/src/main/java/me/snaptime/social/service/SnapLikeService.java
@@ -56,4 +56,16 @@ public class SnapLikeService {
 
         return snapLikeRepository.countBySnap(snap);
     }
+
+    // 자신이 좋아요를 누른 스냅인지 여부 체크
+    public boolean isLikedSnap(Long snapId, String loginId){
+        Snap snap = snapRepository.findById(snapId)
+                .orElseThrow(() -> new CustomException(ExceptionCode.SNAP_NOT_EXIST));
+
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
+
+        return snapLikeRepository.existsBySnapAndUser(snap,user);
+    }
+
 }

--- a/src/test/java/me/snaptime/snap/service/SnapServiceImplTest.java
+++ b/src/test/java/me/snaptime/snap/service/SnapServiceImplTest.java
@@ -3,33 +3,15 @@ package me.snaptime.snap.service;
 import me.snaptime.common.component.UrlComponent;
 import me.snaptime.snap.component.encryption.EncryptionComponent;
 import me.snaptime.snap.component.file.FileComponent;
-import me.snaptime.snap.data.domain.Encryption;
-import me.snaptime.snap.data.domain.Snap;
-import me.snaptime.snap.data.dto.file.WritePhotoToFileSystemResult;
-import me.snaptime.snap.data.dto.req.CreateSnapReqDto;
 import me.snaptime.snap.data.repository.AlbumRepository;
 import me.snaptime.snap.data.repository.SnapRepository;
 import me.snaptime.snap.service.impl.SnapServiceImpl;
-import me.snaptime.snap.util.EncryptionUtil;
-import me.snaptime.snap.util.FileNameGenerator;
-import me.snaptime.user.data.domain.User;
 import me.snaptime.user.data.repository.UserRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Optional;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.spy;
 
 @ExtendWith(MockitoExtension.class)
 public class SnapServiceImplTest {

--- a/src/test/java/me/snaptime/social/controller/FriendShipControllerTest.java
+++ b/src/test/java/me/snaptime/social/controller/FriendShipControllerTest.java
@@ -335,14 +335,14 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWING")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("친구조회가 완료되었습니다."))
                 .andDo(print());
 
         verify(friendShipService,times(1))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq(null));
+                .findFriendList(any(String.class),any(String.class),any(Long.class),any(FriendSearchType.class),eq(null));
     }
 
     @Test
@@ -354,14 +354,14 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWER")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("친구조회가 완료되었습니다."))
                 .andDo(print());
 
         verify(friendShipService,times(1))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq(null));
+                .findFriendList(any(String.class),any(String.class),any(Long.class),any(FriendSearchType.class),eq(null));
     }
 
     @Test
@@ -373,7 +373,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWING")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -381,7 +381,7 @@ public class FriendShipControllerTest {
                 .andDo(print());
 
         verify(friendShipService,times(1))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
+                .findFriendList(any(String.class),any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
     }
 
     @Test
@@ -393,7 +393,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","TEST")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -401,7 +401,7 @@ public class FriendShipControllerTest {
                 .andDo(print());
 
         verify(friendShipService,times(0))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
+                .findFriendList(any(String.class),any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
     }
 
     @Test
@@ -413,7 +413,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}","test")
                         .param("friendSearchType","FOLLOWER")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -421,7 +421,7 @@ public class FriendShipControllerTest {
                 .andDo(print());
 
         verify(friendShipService,times(0))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
+                .findFriendList(any(String.class),any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
     }
 
     @Test
@@ -433,7 +433,7 @@ public class FriendShipControllerTest {
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -441,7 +441,7 @@ public class FriendShipControllerTest {
                 .andDo(print());
 
         verify(friendShipService,times(0))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
+                .findFriendList(any(String.class), any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
     }
 
     @Test
@@ -450,12 +450,13 @@ public class FriendShipControllerTest {
     public void findFriendListTest7() throws Exception {
         //given
         doThrow(new CustomException(ExceptionCode.PAGE_NOT_FOUND))
-                .when(friendShipService).findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
+                .when(friendShipService).findFriendList(any(String.class),any(String.class),any(Long.class),
+                                                        any(FriendSearchType.class),eq("박"));
 
         //when, then
         this.mockMvc.perform(get("/friends/{pageNum}",1L)
                         .param("friendSearchType","FOLLOWER")
-                        .param("loginId","tempLoginId")
+                        .param("targetLoginId","tempLoginId")
                         .param("searchKeyword","박")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -463,6 +464,7 @@ public class FriendShipControllerTest {
                 .andDo(print());
 
         verify(friendShipService,times(1))
-                .findFriendList(any(String.class),any(Long.class),any(FriendSearchType.class),eq("박"));
+                .findFriendList(any(String.class),any(String.class),any(Long.class),any(FriendSearchType.class),
+                                eq("박"));
     }
 }

--- a/src/test/java/me/snaptime/social/service/FriendShipServiceTest.java
+++ b/src/test/java/me/snaptime/social/service/FriendShipServiceTest.java
@@ -366,7 +366,7 @@ public class FriendShipServiceTest {
 
         // when
         FindFriendResDto result = friendShipService
-                .findFriendList("loginId",1L,FriendSearchType.FOLLOWER,"searchKeyword");
+                .findFriendList("loginId","targetLoginId",1L,FriendSearchType.FOLLOWER,"searchKeyword");
 
         // then
         assertThat(result.friendInfoList().get(0).loginId()).isEqualTo("testLoginId1");
@@ -383,7 +383,7 @@ public class FriendShipServiceTest {
 
         assertThat(result.hasNextPage()).isFalse();
 
-        verify(userRepository,times(1)).findByLoginId(any(String.class));
+        verify(userRepository,times(4)).findByLoginId(any(String.class));
         verify(urlComponent,times(3)).makeProfileURL(any(Long.class));
         verify(friendShipRepository,times(1))
                 .findFriendList(any(User.class),any(FriendSearchType.class),any(Long.class),any(String.class));

--- a/src/test/java/me/snaptime/social/service/ReplyServiceTest.java
+++ b/src/test/java/me/snaptime/social/service/ReplyServiceTest.java
@@ -158,7 +158,7 @@ public class ReplyServiceTest {
             //then
             assertThat(ex.getExceptionCode()).isEqualTo(ExceptionCode.REPLY_NOT_FOUND);
             verify(parentReplyRepository,times(1)).findById(any(Long.class));
-            verify(userRepository,times(2)).findByLoginId(any(String.class));
+            verify(userRepository,times(1)).findByLoginId(any(String.class));
             verify(childReplyRepository,times(0)).save(any(ChildReply.class));
         }
     }


### PR DESCRIPTION
## 📋 이슈 번호
#86 

## 🛠 구현 사항

프론트분의 수정사항 요청을 먼저 반영하기 위해 PR보냅니다.
 
1. 다른 유저의 친구목록 조회 시 자신이 팔로우한 유저인지 여부를 반환하도록 변경했습니다.
2. 스냅조회 시 자신이 좋아요를 눌렀는 지 여부를 반환하도록 변경했습니다.
3. 대댓글 등록 시 태그할 유저가 없는 등록요청일 경우 예외가 발생하는 버그를 수정했습니다.
4. 알림 테이블을 추가했습니다.
5. 핸들러에서 처리하지 않는 예외발생 시 401로 반환되던것을 500을 반환하도록 변경했습니다.

## 📚 기타
