### PR TITLE
[Fix] 회원가입시 NonClassification 앨범을 생성하도록 하였음

### DIFF
--- a/src/main/java/me/snaptime/album/service/impl/AlbumServiceImpl.java
+++ b/src/main/java/me/snaptime/album/service/impl/AlbumServiceImpl.java
@@ -113,7 +113,7 @@ public class AlbumServiceImpl implements AlbumService {
     @Override
     public Long findUserNonClassificationId(User user) {
         List<Album> foundAlbums = albumRepository.findAlbumsByUser(user);
-        return foundAlbums.stream().filter(album -> Objects.equals(album.getName(), nonClassificationName)).findFirst().map(Album::getId).orElseThrow(() -> new CustomException(ExceptionCode.ALBUM_NOT_EXIST));
+        return foundAlbums.stream().filter(album -> Objects.equals(album.getName(), nonClassificationName)).findFirst().map(Album::getId).orElseThrow(() -> new CustomException(ExceptionCode.NON_CLASSIFICATION_ALBUM_IS_NOT_EXIST));
     }
 
     @Override
@@ -151,6 +151,9 @@ public class AlbumServiceImpl implements AlbumService {
         Album foundAlbum = albumRepository.findById(album_id).orElseThrow(() -> new CustomException(ExceptionCode.ALBUM_NOT_EXIST));
         // 사용자가 가지고 있는 non-classification id를 가져온다.
         Long foundNonClassificationId = findUserNonClassificationId(foundUser);
+        if  (foundNonClassificationId.equals(album_id)) {
+            throw new CustomException(ExceptionCode.NOT_DELETE_NON_CLASSIFICATION_ALBUM);
+        }
         Album nonClassificationAlbum = albumRepository.findById(foundNonClassificationId).orElseThrow(() -> new CustomException(ExceptionCode.NON_CLASSIFICATION_ALBUM_IS_NOT_EXIST));
         // 앨범과 연관관계가 맺어져있는 snap들의 목록을 가져온다
         List<Snap> snapList = foundAlbum.getSnap();

--- a/src/main/java/me/snaptime/exception/ExceptionCode.java
+++ b/src/main/java/me/snaptime/exception/ExceptionCode.java
@@ -63,6 +63,7 @@ public enum ExceptionCode {
     ALBUM_ID_IS_NOT_GIVEN(HttpStatus.BAD_REQUEST, "앨범 id가 주어지지 않았습니다."),
     ALBUM_USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "앨범을 만든 사용자와 일치하지 않습니다."),
     NON_CLASSIFICATION_ALBUM_IS_NOT_EXIST(HttpStatus.BAD_REQUEST, "모든 스냅 앨범이 존재하지 않습니다."),
+    NOT_DELETE_NON_CLASSIFICATION_ALBUM(HttpStatus.BAD_REQUEST, "모든 스냅 앨범은 삭제할 수 없습니다."),
 
     // Jwt Exception
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,  "AccessToken 이 만료되었습니다."),

--- a/src/main/java/me/snaptime/user/service/impl/SignServiceImpl.java
+++ b/src/main/java/me/snaptime/user/service/impl/SignServiceImpl.java
@@ -3,6 +3,7 @@ package me.snaptime.user.service.impl;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.snaptime.album.service.AlbumService;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
 import me.snaptime.jwt.JwtProvider;
@@ -35,6 +36,7 @@ public class SignServiceImpl implements SignService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AlbumService albumService;
 
     @Override
     public UserFindResDto signUp(UserReqDto userReqDto) {
@@ -65,6 +67,9 @@ public class SignServiceImpl implements SignService {
                 .roles(Collections.singletonList("ROLE_USER"))
                 .profilePhoto(profilePhoto)
                 .build();
+
+        // NonClassification 앨범 생성
+        albumService.createNonClassificationAlbum(user);
 
         return UserFindResDto.toDto(userRepository.save(user));
     }

--- a/src/test/java/me/snaptime/user/service/UserServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package me.snaptime.user.service;
 
+import me.snaptime.album.service.AlbumService;
 import me.snaptime.jwt.JwtProvider;
 import me.snaptime.jwt.redis.RefreshToken;
 import me.snaptime.jwt.redis.RefreshTokenRepository;
@@ -56,6 +57,9 @@ class UserServiceTest {
     @Mock
     private JwtProvider jwtProvider;
 
+    @Mock
+    private AlbumService albumService;
+
     private User givenUser;
 
     @BeforeEach
@@ -107,6 +111,7 @@ class UserServiceTest {
                 .then(returnsFirstArg());
         Mockito.when(profilePhotoRepository.save(any(ProfilePhoto.class)))
                 .then(returnsFirstArg());
+        given(albumService.createNonClassificationAlbum(any(User.class))).willReturn(1L);
         //when
         UserFindResDto userFindResDto = signService.signUp(givenRequest);
 


### PR DESCRIPTION
## 📋 이슈 번호
close #129 
## 🛠 구현 사항
NonClassification 앨범이 없어 Album을 삭제하지 못하던 문제를 해결했습니다.
회원가입시 기본적으로 NonClassification 앨범을 생성하도록 했습니다.
## 📚 기타
