### PR TITLE
[Fix] 스냅삭제 시 댓글테이블에 영속성전이가 되지않는 문제 해결

### DIFF
--- a/src/main/java/me/snaptime/reply/domain/ChildReply.java
+++ b/src/main/java/me/snaptime/reply/domain/ChildReply.java
@@ -29,6 +29,7 @@ public class ChildReply extends BaseTimeEntity {
     private User user;
 
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "parent_reply_id",nullable = false)
     private ParentReply parentReply;
 

--- a/src/main/java/me/snaptime/reply/domain/ParentReply.java
+++ b/src/main/java/me/snaptime/reply/domain/ParentReply.java
@@ -27,6 +27,7 @@ public class ParentReply extends BaseTimeEntity {
     private String content;
 
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "snap_id",nullable = false)
     private Snap snap;
 

--- a/src/main/java/me/snaptime/snap/domain/Encryption.java
+++ b/src/main/java/me/snaptime/snap/domain/Encryption.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.snaptime.user.domain.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.crypto.SecretKey;
 
@@ -23,6 +25,7 @@ public class Encryption {
     private SecretKey secretKey;
 
     @OneToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
     private User user;
 


### PR DESCRIPTION
## 📋 이슈 번호
close #133 

## 🛠 구현 사항
1. 댓글테이블에 대해 영속성 전이를 위해 제약조건 추가
2. 유저 삭제 시 encryption테이블에 영속성 전이를 위해 제약조건 추가

## 📚 기타
