### PR TITLE
[Fix] 유저 삭제 시 비밀번호 검증 

### DIFF
--- a/src/main/java/me/snaptime/exception/handler/JwtExceptionHandlerFilter.java
+++ b/src/main/java/me/snaptime/exception/handler/JwtExceptionHandlerFilter.java
@@ -29,8 +29,10 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
             String message = e.getExceptionCode().getMessage();
             if(message.contains("AccessToken")){
                 setErrorResponse(response,ExceptionCode.ACCESS_TOKEN_EXPIRED);
-            }else{
+            }else if(message.contains("RefreshToken")){
                 setErrorResponse(response,ExceptionCode.REFRESH_TOKEN_EXPIRED);
+            }else{
+                setErrorResponse(response, ExceptionCode.USER_NOT_EXIST);
             }
         } catch (DecodingException e) { //jwt 디코딩 중 발생할 수 있는 예외. Base64 형식이 아닌경우, 헤더,페이로드,서명이 유효하지 않은경우, 페이로드 파싱에 문제가 있는경우
             setErrorResponse(response, ExceptionCode.TOKEN_INVALID);

--- a/src/main/java/me/snaptime/user/controller/UserController.java
+++ b/src/main/java/me/snaptime/user/controller/UserController.java
@@ -73,7 +73,7 @@ public class UserController {
     @PatchMapping("/password")
     public ResponseEntity<CommonResponseDto<Void>> changeUser(@AuthenticationPrincipal UserDetails userDetails,
                                                               @RequestParam("password")
-                                                              @NotBlank(message = "로그인 아이디 입력은 필수입니다.") String password) {
+                                                              @NotBlank(message = "패스워드 입력은 필수입니다.") String password) {
         userService.updatePassword(userDetails.getUsername(), password);
         return ResponseEntity.status(HttpStatus.OK).body(
                 new CommonResponseDto<>(
@@ -84,8 +84,10 @@ public class UserController {
 
     @Operation(summary = "유저 삭제",description = "유저 번호로 유저를 삭제합니다.")
     @DeleteMapping()
-    public ResponseEntity<CommonResponseDto<Void>> deleteUser(@AuthenticationPrincipal UserDetails userDetails){
-        userService.deleteUser(userDetails.getUsername());
+    public ResponseEntity<CommonResponseDto<Void>> deleteUser(@AuthenticationPrincipal UserDetails userDetails,
+                                                              @RequestParam("password")
+                                                              @NotBlank(message = "패스워드 입력은 필수입니다.") String password){
+        userService.deleteUser(password, userDetails.getUsername());
         return ResponseEntity.status(HttpStatus.OK).body(
                 new CommonResponseDto<>(
                         "유저 삭제가 성공적으로 완료되었습니다.",

--- a/src/main/java/me/snaptime/user/service/UserService.java
+++ b/src/main/java/me/snaptime/user/service/UserService.java
@@ -8,6 +8,6 @@ public interface UserService {
     UserFindResDto getUser(String loginId);
     UserPagingResDto findUserPageByName(String searchKeyword, Long pageNum);
     UserFindResDto updateUser(String loginId, UserUpdateReqDto userUpdateReqDto);
-    void deleteUser(String loginId);
+    void deleteUser(String password, String loginId);
     void updatePassword(String loginId, String password);
 }

--- a/src/main/java/me/snaptime/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/me/snaptime/user/service/impl/UserServiceImpl.java
@@ -77,8 +77,12 @@ public class UserServiceImpl implements UserService {
         return UserFindResDto.toDto(user);
     }
 
-    public void deleteUser(String loginId) {
+    public void deleteUser(String password, String loginId) {
+
         User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_EXIST));
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(ExceptionCode.PASSWORD_NOT_EQUAL);
+        }
         userRepository.deleteById(user.getUserId());
     }
 

--- a/src/test/java/me/snaptime/user/controller/UserControllerTest.java
+++ b/src/test/java/me/snaptime/user/controller/UserControllerTest.java
@@ -161,10 +161,10 @@ public class UserControllerTest {
     void deleteUserTest() throws Exception{
         //given
         //when
-        mockMvc.perform(delete("/users"))
+        mockMvc.perform(delete("/users").param("password", "test1234"))
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        verify(userService,times(1)).deleteUser("kang4746");
+        verify(userService,times(1)).deleteUser("test1234","kang4746");
     }
 }

--- a/src/test/java/me/snaptime/user/service/UserServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/UserServiceTest.java
@@ -169,7 +169,7 @@ class UserServiceTest {
         Mockito.when(userRepository.findByLoginId("kang4746"))
                 .thenReturn(Optional.of(user));
         //when
-        userService.deleteUser("kang4746");
+        userService.deleteUser("kang476","kang4746");
 
         //then
         verify(userRepository,times(1)).findByLoginId("kang4746");

--- a/src/test/java/me/snaptime/user/service/UserServiceTest.java
+++ b/src/test/java/me/snaptime/user/service/UserServiceTest.java
@@ -168,8 +168,12 @@ class UserServiceTest {
 
         Mockito.when(userRepository.findByLoginId("kang4746"))
                 .thenReturn(Optional.of(user));
+
+        Mockito.when(passwordEncoder.matches("test1234", user.getPassword()))
+                .thenReturn(true);
+
         //when
-        userService.deleteUser("kang476","kang4746");
+        userService.deleteUser("test1234","kang4746");
 
         //then
         verify(userRepository,times(1)).findByLoginId("kang4746");


### PR DESCRIPTION
## 📋 이슈 번호
close #135 
## 🛠 구현 사항
유저 삭제 시 비밀번호 검증을 추가하였습니다.
## 📚 기타
