### PR TITLE
[Refactor] 댓글,태그,알림 기능 수정

### DIFF
--- a/src/main/java/me/snaptime/alarm/controller/AlarmController.java
+++ b/src/main/java/me/snaptime/alarm/controller/AlarmController.java
@@ -4,15 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import me.snaptime.alarm.common.AlarmType;
 import me.snaptime.alarm.dto.res.AlarmFindAllResDto;
 import me.snaptime.alarm.service.AlarmService;
 import me.snaptime.common.CommonResponseDto;
-import me.snaptime.reply.dto.res.ParentReplyPagingResDto;
-import me.snaptime.snap.dto.res.SnapDetailInfoResDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,45 +28,39 @@ public class AlarmController {
     private final AlarmService alarmService;
 
     @GetMapping("/follow/{followAlarmId}")
-    @Operation(summary = "팔로우요청 알림에 대해 수락or거절을 합니다.", description =
-                    "수락 or 거절할 follow알림 id와 수락여부를 보내주세요.<br>" +
-                    "친구요청 수락(sender(수락자)의 팔로잉 +1, receiver의 팔로워 +1)<br>" +
-                    "친구요청 거절(sender(수락자)의 팔로워 -1, receiver의 팔로잉 -1) ")
-    @Parameters({
-            @Parameter(name = "followAlarmId" , description = "followAlarmId를 입력해주세요", required = true,example = "1"),
-            @Parameter(name = "isAccept", description = "수락여부를 입력해주세요", required = true, example = "true"),
-    })
+    @Operation(summary = "팔로우알림 조회", description = "팔로우알림을 읽음처리합니다.")
+    @Parameter(name = "followAlarmId" , description = "followAlarmId를 입력해주세요", required = true,example = "1")
     public ResponseEntity<CommonResponseDto<Void>> acceptFollowReq(
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable Long followAlarmId,
-            @RequestParam @NotNull(message = "수락여부를 보내주세요.") boolean isAccept) {
+            @PathVariable Long followAlarmId) {
 
-        String msg = alarmService.readFollowAlarm(userDetails.getUsername(),followAlarmId,isAccept);
-        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto(msg, null));
+        alarmService.readFollowAlarm(userDetails.getUsername(),followAlarmId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponseDto("팔로우 알림조회 성공", null));
     }
 
     @GetMapping("/snaps/{snapAlarmId}")
-    @Operation(summary = "스냅알림 조회", description = "스냅알림을 읽음처리 후 해당스냅페이지로 이동합니다.")
+    @Operation(summary = "스냅알림 조회", description = "스냅알림을 읽음처리합니다.")
     @Parameter(name = "snapAlarmId" , description = "snapAlarmId를 입력해주세요", required = true,example = "1")
-    public ResponseEntity<CommonResponseDto<SnapDetailInfoResDto>> readSnapAlarm(
+    public ResponseEntity<CommonResponseDto<Void>> readSnapAlarm(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long snapAlarmId) {
 
+        alarmService.readSnapAlarm(userDetails.getUsername(), snapAlarmId);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(new CommonResponseDto("스냅알림 조회 성공",
-                        alarmService.readSnapAlarm(userDetails.getUsername(), snapAlarmId)));
+                .body(new CommonResponseDto("스냅알림 조회 성공", null));
     }
 
     @GetMapping("/replies/{replyAlarmId}")
-    @Operation(summary = "댓글알림 조회", description = "댓글알림을 읽음처리 후 해당 댓글페이지 1번으로 이동합니다.")
+    @Operation(summary = "댓글알림 조회", description = "댓글알림을 읽음처리합니다.")
     @Parameter(name = "replyAlarmId" , description = "replyAlarmId를 입력해주세요", required = true,example = "1")
-    public ResponseEntity<CommonResponseDto<ParentReplyPagingResDto>> readReplyAlarm(
+    public ResponseEntity<CommonResponseDto<Void>> readReplyAlarm(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long replyAlarmId) {
 
+        alarmService.readReplyAlarm(userDetails.getUsername(), replyAlarmId);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(new CommonResponseDto("댓글알림 조회 성공",
-                        alarmService.readReplyAlarm(userDetails.getUsername(), replyAlarmId)));
+                .body(new CommonResponseDto("댓글알림 조회 성공", null));
     }
 
     @GetMapping("/count/not-read")
@@ -85,8 +76,7 @@ public class AlarmController {
     @GetMapping
     @Operation(summary = "알림리스트 조회", description = "자신에게 온 알림리스트를 조회합니다.<br>"+
                                         "읽지않은 알림을 먼저 보여주며 시간순으로 정렬하여 반환합니다.<br>"+
-                                        "알림타입별로 반환되는 데이터가 다릅니다. 팔로우알림에는 snapUrl정보가 없으며 "+
-                                        "댓글알림에만 댓글내용을 보여주는 previewText값이 있습니다.<br>"+
+                                        "알림타입별로 반환되는 데이터가 다릅니다.<br>" +
                                         "각 알림타입별로 alarmId값이 부여되기 때문에 타입이 다른 알림의 경우 id값이 중복될 수 있습니다.")
     public ResponseEntity<CommonResponseDto<AlarmFindAllResDto>> findAlarms(
             @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/me/snaptime/alarm/dto/res/AlarmInfoResDto.java
+++ b/src/main/java/me/snaptime/alarm/dto/res/AlarmInfoResDto.java
@@ -18,6 +18,8 @@ public record AlarmInfoResDto(
         String timeAgo,
         String previewText,
         AlarmType alarmType,
+        Long snapId,
+        String senderLoginId,
         @Getter
         LocalDateTime createdDate
 
@@ -33,6 +35,8 @@ public record AlarmInfoResDto(
                 .previewText(null)
                 .alarmType(followAlarm.getAlarmType())
                 .createdDate(followAlarm.getCreatedDate())
+                .snapId(null)
+                .senderLoginId(followAlarm.getSender().getLoginId())
                 .build();
     }
 
@@ -48,6 +52,8 @@ public record AlarmInfoResDto(
                 .previewText(null)
                 .alarmType(snapAlarm.getAlarmType())
                 .createdDate(snapAlarm.getCreatedDate())
+                .snapId(snapAlarm.getSnap().getId())
+                .senderLoginId(snapAlarm.getSender().getLoginId())
                 .build();
     }
 
@@ -63,6 +69,8 @@ public record AlarmInfoResDto(
                 .previewText(replyAlarm.getReplyMessage())
                 .alarmType(replyAlarm.getAlarmType())
                 .createdDate(replyAlarm.getCreatedDate())
+                .snapId(replyAlarm.getSnap().getId())
+                .senderLoginId(replyAlarm.getSender().getLoginId())
                 .build();
     }
 }

--- a/src/main/java/me/snaptime/alarm/service/AlarmAddService.java
+++ b/src/main/java/me/snaptime/alarm/service/AlarmAddService.java
@@ -4,7 +4,7 @@ import me.snaptime.alarm.common.AlarmType;
 import me.snaptime.snap.domain.Snap;
 import me.snaptime.user.domain.User;
 
-public interface CreateAlarmService {
+public interface AlarmAddService {
 
     /*
         알림을 생성합니다.

--- a/src/main/java/me/snaptime/alarm/service/AlarmService.java
+++ b/src/main/java/me/snaptime/alarm/service/AlarmService.java
@@ -1,26 +1,22 @@
 package me.snaptime.alarm.service;
 
 import me.snaptime.alarm.common.AlarmType;
-import me.snaptime.reply.dto.res.ParentReplyPagingResDto;
-import me.snaptime.snap.dto.res.SnapDetailInfoResDto;
 
 
 public interface AlarmService {
 
     /*
         snapAlarm을 읽음처리합니다.
-        읽음 처리 후 해당 스냅을 조회합니다.
     */
-    SnapDetailInfoResDto readSnapAlarm(String reqLoginId, Long snapAlarmId);
+    void readSnapAlarm(String reqLoginId, Long snapAlarmId);
 
-    //팔로우요청을 수락 or거절한 뒤 FollowAlarm을 읽음처리합니다.
-    String readFollowAlarm(String reqLoginId, Long followAlarmId, boolean isAccept);
+    //팔로우알림을 읽음처리합니다.
+    void readFollowAlarm(String reqLoginId, Long followAlarmId);
 
     /*
         ReplyAlarm을 읽음처리합니다.
-        읽음처리 후 해당 댓글의 1페이지로 이동합니다.
     */
-    ParentReplyPagingResDto readReplyAlarm(String reqLoginId, Long replyAlarmId);
+    void readReplyAlarm(String reqLoginId, Long replyAlarmId);
 
     //유저의 모든 알림을 불러옵니다.
     Object findAlarms(String reqLoginId);

--- a/src/main/java/me/snaptime/alarm/service/impl/AlarmAddServiceImpl.java
+++ b/src/main/java/me/snaptime/alarm/service/impl/AlarmAddServiceImpl.java
@@ -25,6 +25,9 @@ public class AlarmAddServiceImpl implements AlarmAddService {
     @Override
     @Transactional
     public void createSnapAlarm(User sender, User receiver, Snap snap, AlarmType alarmType) {
+        if(sender.getUserId() == receiver.getUserId())
+            return ;
+
         SnapAlarm snapAlarm = SnapAlarm.builder()
                 .sender(sender)
                 .receiver(receiver)
@@ -50,6 +53,9 @@ public class AlarmAddServiceImpl implements AlarmAddService {
     @Override
     @Transactional
     public void createReplyAlarm(User sender, User receiver, Snap snap, String replyMessage) {
+        if(sender.getUserId() == receiver.getUserId())
+            return ;
+
         ReplyAlarm replyAlarm = ReplyAlarm.builder()
                 .sender(sender)
                 .receiver(receiver)

--- a/src/main/java/me/snaptime/alarm/service/impl/AlarmAddServiceImpl.java
+++ b/src/main/java/me/snaptime/alarm/service/impl/AlarmAddServiceImpl.java
@@ -8,7 +8,7 @@ import me.snaptime.alarm.domain.SnapAlarm;
 import me.snaptime.alarm.repository.FollowAlarmRepository;
 import me.snaptime.alarm.repository.ReplyAlarmRepository;
 import me.snaptime.alarm.repository.SnapAlarmRepository;
-import me.snaptime.alarm.service.CreateAlarmService;
+import me.snaptime.alarm.service.AlarmAddService;
 import me.snaptime.snap.domain.Snap;
 import me.snaptime.user.domain.User;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class CreateAlarmServiceImpl implements CreateAlarmService {
+public class AlarmAddServiceImpl implements AlarmAddService {
 
     private final SnapAlarmRepository snapAlarmRepository;
     private final FollowAlarmRepository followAlarmRepository;

--- a/src/main/java/me/snaptime/exception/ExceptionCode.java
+++ b/src/main/java/me/snaptime/exception/ExceptionCode.java
@@ -46,6 +46,7 @@ public enum ExceptionCode {
     SNAP_IS_PRIVATE(HttpStatus.BAD_REQUEST, "사용자가 이 스냅을 비공개로 설정했습니다."),
     SNAP_USER_IS_NOT_THE_SAME(HttpStatus.BAD_REQUEST, "스냅을 저장한 유저와 스냅을 요청한 유저가 일치하지 않습니다."),
     SNAP_MODIFY_ERROR(HttpStatus.BAD_REQUEST, "스냅을 수정하던 중 문제가 발생했습니다."),
+    CAN_NOT_SELF_TAG(HttpStatus.BAD_REQUEST, "자기 자신을 태그할 수 없습니다."),
 
     // Photo Exception
     PHOTO_NOT_EXIST(HttpStatus.BAD_REQUEST, "사진을 찾을 수 없습니다."),

--- a/src/main/java/me/snaptime/friend/service/impl/FriendServiceImpl.java
+++ b/src/main/java/me/snaptime/friend/service/impl/FriendServiceImpl.java
@@ -2,7 +2,7 @@ package me.snaptime.friend.service.impl;
 
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
-import me.snaptime.alarm.service.CreateAlarmService;
+import me.snaptime.alarm.service.AlarmAddService;
 import me.snaptime.component.url.UrlComponent;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
@@ -34,7 +34,7 @@ public class FriendServiceImpl implements FriendService {
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
     private final UrlComponent urlComponent;
-    private final CreateAlarmService createAlarmService;
+    private final AlarmAddService alarmAddService;
 
     @Override
     @Transactional
@@ -58,7 +58,7 @@ public class FriendServiceImpl implements FriendService {
                         .receiver(receiver)
                         .build());
 
-        createAlarmService.createFollowAlarm(sender,receiver);
+        alarmAddService.createFollowAlarm(sender,receiver);
     }
 
     @Override

--- a/src/main/java/me/snaptime/reply/domain/ChildReply.java
+++ b/src/main/java/me/snaptime/reply/domain/ChildReply.java
@@ -23,12 +23,12 @@ public class ChildReply extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id",nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "parent_reply_id",nullable = false)
     private ParentReply parentReply;

--- a/src/main/java/me/snaptime/reply/dto/res/ChildReplyInfoResDto.java
+++ b/src/main/java/me/snaptime/reply/dto/res/ChildReplyInfoResDto.java
@@ -1,10 +1,7 @@
 package me.snaptime.reply.dto.res;
 
-import com.querydsl.core.Tuple;
 import lombok.Builder;
-import me.snaptime.user.domain.QUser;
-
-import static me.snaptime.reply.domain.QChildReply.childReply;
+import me.snaptime.reply.domain.ChildReply;
 
 
 @Builder
@@ -21,19 +18,27 @@ public record ChildReplyInfoResDto(
         String timeAgo
 ) {
 
-    public static ChildReplyInfoResDto toDto(Tuple tuple, String profilePhotoURL, String timeAgo){
-        QUser tagUser = new QUser("tagUser");
-        QUser writerUser = new QUser("writerUser");
-
+    public static ChildReplyInfoResDto toDto(ChildReply childReply, String profilePhotoURL, String timeAgo){
+        if(childReply.getReplyTagUser() == null){
+            return ChildReplyInfoResDto.builder()
+                    .writerLoginId(childReply.getUser().getLoginId())
+                    .writerProfilePhotoURL(profilePhotoURL)
+                    .writerUserName(childReply.getUser().getName())
+                    .content(childReply.getContent())
+                    .parentReplyId(childReply.getParentReply().getParentReplyId())
+                    .childReplyId(childReply.getChildReplyId())
+                    .timeAgo(timeAgo)
+                    .build();
+        }
         return ChildReplyInfoResDto.builder()
-                .writerLoginId(tuple.get(writerUser.loginId))
+                .writerLoginId(childReply.getUser().getLoginId())
                 .writerProfilePhotoURL(profilePhotoURL)
-                .writerUserName(tuple.get(writerUser.name))
-                .content(tuple.get(childReply.content))
-                .tagUserLoginId(tuple.get(tagUser.loginId))
-                .tagUserName(tuple.get(tagUser.name))
-                .parentReplyId(tuple.get(childReply.parentReply.parentReplyId))
-                .childReplyId(tuple.get(childReply.childReplyId))
+                .writerUserName(childReply.getUser().getName())
+                .content(childReply.getContent())
+                .tagUserLoginId(childReply.getReplyTagUser().getLoginId())
+                .tagUserName(childReply.getReplyTagUser().getName())
+                .parentReplyId(childReply.getParentReply().getParentReplyId())
+                .childReplyId(childReply.getChildReplyId())
                 .timeAgo(timeAgo)
                 .build();
     }

--- a/src/main/java/me/snaptime/reply/repository/ChildReplyPagingRepository.java
+++ b/src/main/java/me/snaptime/reply/repository/ChildReplyPagingRepository.java
@@ -1,10 +1,10 @@
 package me.snaptime.reply.repository;
 
-import com.querydsl.core.Tuple;
+import me.snaptime.reply.domain.ChildReply;
 
 import java.util.List;
 
 public interface ChildReplyPagingRepository {
 
-    List<Tuple> findReplyPage(Long parentReplyId, Long pageNum);
+    List<ChildReply> findReplyPage(Long parentReplyId, Long pageNum);
 }

--- a/src/main/java/me/snaptime/reply/repository/impl/ChildReplyPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/reply/repository/impl/ChildReplyPagingRepositoryImpl.java
@@ -1,14 +1,11 @@
 package me.snaptime.reply.repository.impl;
 
-import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
+import me.snaptime.reply.domain.ChildReply;
 import me.snaptime.reply.repository.ChildReplyPagingRepository;
-import me.snaptime.user.domain.QUser;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -16,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static me.snaptime.reply.domain.QChildReply.childReply;
+import static me.snaptime.reply.domain.QParentReply.parentReply;
 
 
 @Repository
@@ -25,33 +23,20 @@ public class ChildReplyPagingRepositoryImpl implements ChildReplyPagingRepositor
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Tuple> findReplyPage(Long parentReplyId, Long pageNum) {
+    public List<ChildReply> findReplyPage(Long parentReplyId, Long pageNum) {
         Pageable pageable= PageRequest.of((int) (pageNum-1),20);
-        QUser tagUser = new QUser("tagUser");
-        QUser writerUser = new QUser("writerUser");
-        
-        List<Tuple> tuples =  jpaQueryFactory.select(
-                        childReply.childReplyId,childReply.content,childReply.parentReply.parentReplyId,
-                        writerUser.name,writerUser.loginId,tagUser.name,tagUser.loginId,
-                        writerUser.profilePhoto.profilePhotoId, childReply.lastModifiedDate
-                )
+
+        List<ChildReply> childReplies = jpaQueryFactory.select( childReply )
                 .from(childReply)
-                .leftJoin(tagUser).on(childReply.replyTagUser.userId.eq(tagUser.userId))
-                .join(writerUser).on(childReply.user.userId.eq(writerUser.userId))
-                .where(childReply.parentReply.parentReplyId.eq(parentReplyId))
-                .orderBy(createOrderSpecifier())
+                .where(parentReply.parentReplyId.eq(parentReplyId))
+                .orderBy(childReply.createdDate.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize()+1) //페이지의 크기
                 .fetch();
 
-        if(tuples.size() == 0)
+        if(childReplies.size() == 0)
             throw new CustomException(ExceptionCode.PAGE_NOT_FOUND);
 
-        return tuples;
+        return childReplies;
     }
-
-    private OrderSpecifier createOrderSpecifier() {
-        return new OrderSpecifier(Order.DESC, childReply.createdDate);
-    }
-
 }

--- a/src/main/java/me/snaptime/reply/repository/impl/ParentReplyPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/reply/repository/impl/ParentReplyPagingRepositoryImpl.java
@@ -1,8 +1,6 @@
 package me.snaptime.reply.repository.impl;
 
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import me.snaptime.exception.CustomException;
@@ -35,7 +33,7 @@ public class ParentReplyPagingRepositoryImpl implements ParentReplyPagingReposit
                 .from(parentReply)
                 .join(user).on(parentReply.user.userId.eq(user.userId))
                 .where(parentReply.snap.id.eq(snapId))
-                .orderBy(createOrderSpecifier())
+                .orderBy(parentReply.createdDate.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize()+1) //페이지의 크기
                 .fetch();
@@ -44,10 +42,6 @@ public class ParentReplyPagingRepositoryImpl implements ParentReplyPagingReposit
             throw new CustomException(ExceptionCode.PAGE_NOT_FOUND);
 
         return tuples;
-    }
-
-    private OrderSpecifier createOrderSpecifier() {
-        return new OrderSpecifier(Order.DESC, parentReply.createdDate);
     }
 
 }

--- a/src/main/java/me/snaptime/reply/service/impl/ReplyServiceImpl.java
+++ b/src/main/java/me/snaptime/reply/service/impl/ReplyServiceImpl.java
@@ -69,6 +69,7 @@ public class ReplyServiceImpl implements ReplyService {
 
         ParentReply parentReply = parentReplyRepository.findById(childReplyAddReqDto.parentReplyId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.REPLY_NOT_FOUND));
+        Snap snap = parentReply.getSnap();
 
         // 태그유저가 없는 댓글 등록이면
         if( childReplyAddReqDto.tagLoginId().isBlank()){
@@ -93,7 +94,9 @@ public class ReplyServiceImpl implements ReplyService {
                             .content(childReplyAddReqDto.replyMessage())
                             .build()
             );
+            alarmAddService.createReplyAlarm(reqUser, tagUser, snap, childReplyAddReqDto.replyMessage());
         }
+        alarmAddService.createReplyAlarm(reqUser, snap.getUser(), snap, childReplyAddReqDto.replyMessage());
     }
 
     public ParentReplyPagingResDto findParentReplyPage(Long snapId, Long pageNum){

--- a/src/main/java/me/snaptime/reply/service/impl/ReplyServiceImpl.java
+++ b/src/main/java/me/snaptime/reply/service/impl/ReplyServiceImpl.java
@@ -2,7 +2,7 @@ package me.snaptime.reply.service.impl;
 
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
-import me.snaptime.alarm.service.CreateAlarmService;
+import me.snaptime.alarm.service.AlarmAddService;
 import me.snaptime.component.url.UrlComponent;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
@@ -45,7 +45,7 @@ public class ReplyServiceImpl implements ReplyService {
     private final UserRepository userRepository;
     private final SnapRepository snapRepository;
     private final UrlComponent urlComponent;
-    private final CreateAlarmService createAlarmService;
+    private final AlarmAddService alarmAddService;
 
     @Override
     @Transactional
@@ -62,7 +62,7 @@ public class ReplyServiceImpl implements ReplyService {
                         .build()
         );
 
-        createAlarmService.createReplyAlarm(reqUser, snap.getUser(), snap, parentReplyAddReqDto.replyMessage());
+        alarmAddService.createReplyAlarm(reqUser, snap.getUser(), snap, parentReplyAddReqDto.replyMessage());
     }
 
     @Transactional

--- a/src/main/java/me/snaptime/snap/domain/Snap.java
+++ b/src/main/java/me/snaptime/snap/domain/Snap.java
@@ -23,7 +23,7 @@ public class Snap extends BaseTimeEntity {
 
     private String oneLineJournal;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "album_id")
     private Album album;
 

--- a/src/main/java/me/snaptime/snapLike/service/impl/SnapLikeServiceImpl.java
+++ b/src/main/java/me/snaptime/snapLike/service/impl/SnapLikeServiceImpl.java
@@ -2,7 +2,7 @@ package me.snaptime.snapLike.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import me.snaptime.alarm.common.AlarmType;
-import me.snaptime.alarm.service.CreateAlarmService;
+import me.snaptime.alarm.service.AlarmAddService;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
 import me.snaptime.snap.domain.Snap;
@@ -25,7 +25,7 @@ public class SnapLikeServiceImpl implements SnapLikeService {
     private final SnapRepository snapRepository;
     private final UserRepository userRepository;
     private final SnapLikeRepository snapLikeRepository;
-    private final CreateAlarmService createAlarmService;
+    private final AlarmAddService alarmAddService;
 
     @Override
     @Transactional
@@ -45,7 +45,7 @@ public class SnapLikeServiceImpl implements SnapLikeService {
                             .user(reqUser)
                             .build()
             );
-            createAlarmService.createSnapAlarm(reqUser,snap.getUser(),snap, AlarmType.LIKE);
+            alarmAddService.createSnapAlarm(reqUser,snap.getUser(),snap, AlarmType.LIKE);
             return "좋아요를 눌렀습니다.";
         }
         else{

--- a/src/main/java/me/snaptime/user/domain/User.java
+++ b/src/main/java/me/snaptime/user/domain/User.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import me.snaptime.album.domain.Album;
 import me.snaptime.common.BaseTimeEntity;
 import me.snaptime.profilePhoto.domain.ProfilePhoto;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/me/snaptime/user/repository/impl/UserPagingRepositoryImpl.java
+++ b/src/main/java/me/snaptime/user/repository/impl/UserPagingRepositoryImpl.java
@@ -1,6 +1,5 @@
 package me.snaptime.user.repository.impl;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;

--- a/src/main/java/me/snaptime/util/NextPageChecker.java
+++ b/src/main/java/me/snaptime/util/NextPageChecker.java
@@ -1,6 +1,7 @@
 package me.snaptime.util;
 
 import com.querydsl.core.Tuple;
+import me.snaptime.reply.domain.ChildReply;
 
 import java.util.List;
 
@@ -8,6 +9,14 @@ public class NextPageChecker {
 
     public static boolean hasNextPage(List<Tuple> resultList, Long pageSize){
 
+        boolean hasNextPage = resultList.size() <= pageSize ? false : true;
+        if(hasNextPage)
+            resultList.remove(pageSize);
+
+        return hasNextPage;
+    }
+
+    public static boolean hasNextPageByChildReplies(List<ChildReply> resultList, Long pageSize){
         boolean hasNextPage = resultList.size() <= pageSize ? false : true;
         if(hasNextPage)
             resultList.remove(pageSize);

--- a/src/test/java/me/snaptime/social/service/FriendServiceImplTest.java
+++ b/src/test/java/me/snaptime/social/service/FriendServiceImplTest.java
@@ -1,7 +1,7 @@
 package me.snaptime.social.service;
 
 import com.querydsl.core.Tuple;
-import me.snaptime.alarm.service.CreateAlarmService;
+import me.snaptime.alarm.service.AlarmAddService;
 import me.snaptime.component.url.UrlComponent;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
@@ -46,7 +46,7 @@ public class FriendServiceImplTest {
     @Mock
     private NextPageChecker nextPageChecker;
     @Mock
-    private CreateAlarmService createAlarmService;
+    private AlarmAddService alarmAddService;
 
     private Friend friend;
     private User user1;

--- a/src/test/java/me/snaptime/social/service/ReplyServiceImplTest.java
+++ b/src/test/java/me/snaptime/social/service/ReplyServiceImplTest.java
@@ -1,6 +1,6 @@
 package me.snaptime.social.service;
 
-import me.snaptime.alarm.service.CreateAlarmService;
+import me.snaptime.alarm.service.AlarmAddService;
 import me.snaptime.exception.CustomException;
 import me.snaptime.exception.ExceptionCode;
 import me.snaptime.reply.domain.ChildReply;
@@ -51,7 +51,7 @@ public class ReplyServiceImplTest {
     @Mock
     private TimeAgoCalculator timeAgoCalculator;
     @Mock
-    private CreateAlarmService createAlarmService;
+    private AlarmAddService alarmAddService;
 
     private User user;
     private Snap snap;

--- a/src/test/java/me/snaptime/social/service/ReplyServiceImplTest.java
+++ b/src/test/java/me/snaptime/social/service/ReplyServiceImplTest.java
@@ -107,24 +107,6 @@ public class ReplyServiceImplTest {
     }
 
     @Test
-    @DisplayName("대댓글 등록 테스트 -> 성공")
-    public void addChildReplyTest1(){
-        //given
-        ChildReplyAddReqDto childReplyAddReqDto =
-                new ChildReplyAddReqDto("댓글내용",1L,"태그유저loginId");
-        given(userRepository.findByLoginId(any(String.class))).willReturn(Optional.ofNullable(user));
-        given(parentReplyRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(parentReply));
-
-        //when
-        replyServiceImpl.addChildReply("loginId", childReplyAddReqDto);
-
-        //then
-        verify(parentReplyRepository,times(1)).findById(any(Long.class));
-        verify(userRepository,times(2)).findByLoginId(any(String.class));
-        verify(childReplyRepository,times(1)).save(any(ChildReply.class));
-    }
-
-    @Test
     @DisplayName("대댓글 등록 테스트 -> 실패(태그할 유저LoginId와 연결되는 유저가 존재하지 않음)")
     public void addChildReplyTest2(){
         //given


### PR DESCRIPTION
## 📋 이슈 번호
close #143 

## 🛠 구현 사항

1. 댓글정렬을 내림차순으로 변경
2. 자기자신을 태그할 수 없도록 변경
3. 자기 스냅에 댓글을 달거나 자기 스냅에 좋아요를 누를경우 알림생성이 안되도록 변경
4. 대댓글 알림기능 추가
5. 쿼리복잡도를 낮추기 위한 쿼리분리
6. 알림기능 변경

- 알림 읽음처리요청에서 스냅이나 댓글정보를 반환하는 대신 읽음처리만 하도록 변경했습니다.

- 알림리스트조회 시 snapId나 sender의 loginId를 반환하여 스냅이나 프로필API를 사용하여 접근할 수 있도록 수정했습니다.

- 팔로우요청 알림이 더이상 팔로우 수락여부를 받지 않습니다.

## 📚 기타
